### PR TITLE
Appropriate clue reveal

### DIFF
--- a/MineSweeper.Tests/ConsoleOutPutTests.cs
+++ b/MineSweeper.Tests/ConsoleOutPutTests.cs
@@ -6,48 +6,5 @@ namespace MineSweeper.Tests
 {
   public class ConsoleOutPutTests
   {
-    [Fact]
-    public void InitialFieldViewRevealsNoSquareData()
-    {
-      var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(4, 4) });
-      var consoleVisuzlier = new ConsoleOutput();
-      var mineField = new MineField(5, 5, 5, minePositioning);
-      var expectedField = "     \n"
-                        + "     \n"
-                        + "     \n"
-                        + "     \n"
-                        + "     \n";
-      Assert.Equal(expectedField, consoleVisuzlier.FieldAsString(mineField));
-    }
-    [Fact]
-    public void RevealsAppropriateSquareHintValue()
-    {
-      var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(4, 4) });
-      var consoleVisuzlier = new ConsoleOutput();
-      var mineField = new MineField(5, 5, 5, minePositioning);
-      var expectedField = "     \n"
-                        + "     \n"
-                        + "     \n"
-                        + "   2 \n"
-                        + "     \n";
-      Assert.Equal(expectedField, consoleVisuzlier.FieldAsString(mineField));
-
-    }
-    [Fact]
-    public void OnLossRevealFullField()
-    {
-      var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(4, 4) });
-      var consoleVisuzlier = new ConsoleOutput();
-      var mineField = new MineField(5, 5, 5, minePositioning);
-      var expectedField = "*1...\n"
-                        + "1211.\n"
-                        + ".1*1.\n"
-                        + ".1121\n"
-                        + "...1*\n";
-      Assert.Equal(expectedField, consoleVisuzlier.FieldAsString(mineField));
-
-    }
-    
-
   }
 }

--- a/MineSweeper.Tests/ConsoleOutPutTests.cs
+++ b/MineSweeper.Tests/ConsoleOutPutTests.cs
@@ -19,11 +19,35 @@ namespace MineSweeper.Tests
                         + "     \n";
       Assert.Equal(expectedField, consoleVisuzlier.FieldAsString(mineField));
     }
-      // var expectedField = "*1   \n"
-      //                   + "1211 \n"
-      //                   + " 1*1 \n"
-      //                   + " 1121\n"
-      //                   + "   1*\n";
+    [Fact]
+    public void RevealsAppropriateSquareHintValue()
+    {
+      var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(4, 4) });
+      var consoleVisuzlier = new ConsoleOutput();
+      var mineField = new MineField(5, 5, 5, minePositioning);
+      var expectedField = "     \n"
+                        + "     \n"
+                        + "     \n"
+                        + "   2 \n"
+                        + "     \n";
+      Assert.Equal(expectedField, consoleVisuzlier.FieldAsString(mineField));
+
+    }
+    [Fact]
+    public void OnLossRevealFullField()
+    {
+      var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(4, 4) });
+      var consoleVisuzlier = new ConsoleOutput();
+      var mineField = new MineField(5, 5, 5, minePositioning);
+      var expectedField = "*1...\n"
+                        + "1211.\n"
+                        + ".1*1.\n"
+                        + ".1121\n"
+                        + "...1*\n";
+      Assert.Equal(expectedField, consoleVisuzlier.FieldAsString(mineField));
+
+    }
+    
 
   }
 }

--- a/MineSweeper.Tests/GameTests.cs
+++ b/MineSweeper.Tests/GameTests.cs
@@ -30,7 +30,7 @@ namespace MineSweeper.Tests
                         + "     \n"
                         + "   2 \n"
                         + "     \n";
-      game.ProcessReveal(new RowColumn(3, 3));
+      game.HandleSelectedSquare(new RowColumn(3, 3));
       Assert.Equal(expectedField, game.FieldAsString());
 
     }
@@ -45,7 +45,7 @@ namespace MineSweeper.Tests
                         + "   1.\n"
                         + "   21\n"
                         + "     \n";
-      game.ProcessReveal(new RowColumn(0, 4));
+      game.HandleSelectedSquare(new RowColumn(0, 4));
       Assert.Equal(expectedField, game.FieldAsString());
 
     }
@@ -61,26 +61,43 @@ namespace MineSweeper.Tests
                         + ".....\n"
                         + ".....\n"
                         + ".....\n";
-      game.ProcessReveal(new RowColumn(0, 4));
+      game.HandleSelectedSquare(new RowColumn(0, 4));
       Assert.Equal(expectedField, game.FieldAsString());
 
     }
-
-
     [Fact]
-    public void OnLossRevealFullField()
+    public void OnLossRevealsAllMinePositionsAndAlreadyUncoveredClues()
     {
       var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(4, 4) });
-      var mineField = new MineField(5, 5, 5, minePositioning);
+      var mineField = new MineField(5, 5, 3, minePositioning);
       var game = new Game(mineField);
+      game.HandleSelectedSquare(new RowColumn(0, 4));
+      game.HandleSelectedSquare(new RowColumn(0, 0));
       var expectedField = "*1...\n"
-                        + "1211.\n"
-                        + ".1*1.\n"
-                        + ".1121\n"
+                        + " 211.\n"
+                        + "  *1.\n"
+                        + "   21\n"
+                        + "    *\n";
+      Assert.Equal(expectedField, game.FieldAsString());
+
+    }
+    [Fact]
+    public void CantLoseOnFirstClickMovesMineToTopLeftReCalculatesSquareHints()
+    {
+      var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(2, 2), new RowColumn(4, 4) });
+      var mineField = new MineField(5, 5, 3, minePositioning);
+      var game = new Game(mineField);
+      game.HandleSelectedSquare(new RowColumn(0, 4));
+      game.HandleSelectedSquare(new RowColumn(0, 0));
+      var expectedField = " 1...\n"
+                        + "11...\n"
+                        + "...1.\n"
+                        + "...11\n"
                         + "...1*\n";
       Assert.Equal(expectedField, game.FieldAsString());
 
     }
+
 
 
 

--- a/MineSweeper.Tests/GameTests.cs
+++ b/MineSweeper.Tests/GameTests.cs
@@ -36,7 +36,6 @@ namespace MineSweeper.Tests
     [Fact]
     public void RevealsAppropriateSquareHintValueWhenEmptySquareSelected()
     {
-      //var selection = 0,4
       var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(4, 4) });
       var mineField = new MineField(5, 5, 5, minePositioning);
       var game = new Game(mineField);
@@ -45,6 +44,7 @@ namespace MineSweeper.Tests
                         + "   1.\n"
                         + "   21\n"
                         + "     \n";
+      game.ProcessTurn(new RowColumn(0, 4));
       Assert.Equal(expectedField, game.FieldAsString());
 
     }

--- a/MineSweeper.Tests/GameTests.cs
+++ b/MineSweeper.Tests/GameTests.cs
@@ -44,7 +44,7 @@ namespace MineSweeper.Tests
                         + "   1.\n"
                         + "   21\n"
                         + "     \n";
-      game.FindEmptySquaresAdjacentToThisEmptySquare(new RowColumn(0, 4));
+      game.ProcessSquareSelection(new RowColumn(0, 4));
       Assert.Equal(expectedField, game.FieldAsString());
 
     }

--- a/MineSweeper.Tests/GameTests.cs
+++ b/MineSweeper.Tests/GameTests.cs
@@ -44,7 +44,7 @@ namespace MineSweeper.Tests
                         + "   1.\n"
                         + "   21\n"
                         + "     \n";
-      game.ProcessTurn(new RowColumn(0, 4));
+      game.FindEmptySquaresAdjacentToThisEmptySquare(new RowColumn(0, 4));
       Assert.Equal(expectedField, game.FieldAsString());
 
     }

--- a/MineSweeper.Tests/GameTests.cs
+++ b/MineSweeper.Tests/GameTests.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using MineSweeper.ConsoleImplementation;
+using Xunit;
+
+namespace MineSweeper.Tests
+{
+    public class GameTests
+    {
+    [Fact]
+    public void InitialFieldViewRevealsNoSquareData()
+    {
+      var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(4, 4) });
+      var mineField = new MineField(5, 5, 5, minePositioning);
+      var expectedField = "     \n"
+                        + "     \n"
+                        + "     \n"
+                        + "     \n"
+                        + "     \n";
+      Assert.Equal(expectedField, Game.FieldAsString(mineField));
+    }
+    [Fact]
+    public void RevealsAppropriateSquareHintValue()
+    {
+      var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(4, 4) });
+      var mineField = new MineField(5, 5, 5, minePositioning);
+      var expectedField = "     \n"
+                        + "     \n"
+                        + "     \n"
+                        + "   2 \n"
+                        + "     \n";
+      Assert.Equal(expectedField, Game.FieldAsString(mineField));
+
+    }
+    [Fact]
+    public void OnLossRevealFullField()
+    {
+      var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(4, 4) });
+      var consoleVisuzlier = new ConsoleOutput();
+      var mineField = new MineField(5, 5, 5, minePositioning);
+      var expectedField = "*1...\n"
+                        + "1211.\n"
+                        + ".1*1.\n"
+                        + ".1121\n"
+                        + "...1*\n";
+      Assert.Equal(expectedField, Game.FieldAsString(mineField));
+
+    }
+    
+
+        
+    }
+}

--- a/MineSweeper.Tests/GameTests.cs
+++ b/MineSweeper.Tests/GameTests.cs
@@ -30,7 +30,7 @@ namespace MineSweeper.Tests
                         + "     \n"
                         + "   2 \n"
                         + "     \n";
-      game.ProcessSquareSelection(new RowColumn(3, 3));
+      game.ProcessReveal(new RowColumn(3, 3));
       Assert.Equal(expectedField, game.FieldAsString());
 
     }
@@ -45,10 +45,27 @@ namespace MineSweeper.Tests
                         + "   1.\n"
                         + "   21\n"
                         + "     \n";
-      game.ProcessSquareSelection(new RowColumn(0, 4));
+      game.ProcessReveal(new RowColumn(0, 4));
       Assert.Equal(expectedField, game.FieldAsString());
 
     }
+
+    [Fact]
+    public void BalloonsCluesOutAppropriately()
+    {
+      var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0)});
+      var mineField = new MineField(5, 5, 5, minePositioning);
+      var game = new Game(mineField);
+      var expectedField = " 1...\n"
+                        + "11...\n"
+                        + ".....\n"
+                        + ".....\n"
+                        + ".....\n";
+      game.ProcessReveal(new RowColumn(0, 4));
+      Assert.Equal(expectedField, game.FieldAsString());
+
+    }
+
 
     [Fact]
     public void OnLossRevealFullField()

--- a/MineSweeper.Tests/GameTests.cs
+++ b/MineSweeper.Tests/GameTests.cs
@@ -4,49 +4,67 @@ using Xunit;
 
 namespace MineSweeper.Tests
 {
-    public class GameTests
-    {
+  public class GameTests
+  {
     [Fact]
     public void InitialFieldViewRevealsNoSquareData()
     {
       var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(4, 4) });
       var mineField = new MineField(5, 5, 5, minePositioning);
+      var game = new Game(mineField);
       var expectedField = "     \n"
                         + "     \n"
                         + "     \n"
                         + "     \n"
                         + "     \n";
-      Assert.Equal(expectedField, Game.FieldAsString(mineField));
+      Assert.Equal(expectedField, game.FieldAsString());
     }
     [Fact]
     public void RevealsAppropriateSquareHintValue()
     {
       var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(4, 4) });
       var mineField = new MineField(5, 5, 5, minePositioning);
+      var game = new Game(mineField);
       var expectedField = "     \n"
                         + "     \n"
                         + "     \n"
                         + "   2 \n"
                         + "     \n";
-      Assert.Equal(expectedField, Game.FieldAsString(mineField));
+      Assert.Equal(expectedField, game.FieldAsString());
 
     }
+    [Fact]
+    public void RevealsAppropriateSquareHintValueWhenEmptySquareSelected()
+    {
+      //var selection = 0,4
+      var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(4, 4) });
+      var mineField = new MineField(5, 5, 5, minePositioning);
+      var game = new Game(mineField);
+      var expectedField = " 1...\n"
+                        + " 211.\n"
+                        + "   1.\n"
+                        + "   21\n"
+                        + "     \n";
+      Assert.Equal(expectedField, game.FieldAsString());
+
+    }
+
     [Fact]
     public void OnLossRevealFullField()
     {
       var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(4, 4) });
-      var consoleVisuzlier = new ConsoleOutput();
       var mineField = new MineField(5, 5, 5, minePositioning);
+      var game = new Game(mineField);
       var expectedField = "*1...\n"
                         + "1211.\n"
                         + ".1*1.\n"
                         + ".1121\n"
                         + "...1*\n";
-      Assert.Equal(expectedField, Game.FieldAsString(mineField));
+      Assert.Equal(expectedField, game.FieldAsString());
 
     }
-    
 
-        
-    }
+
+
+  }
 }

--- a/MineSweeper.Tests/GameTests.cs
+++ b/MineSweeper.Tests/GameTests.cs
@@ -30,6 +30,7 @@ namespace MineSweeper.Tests
                         + "     \n"
                         + "   2 \n"
                         + "     \n";
+      game.SelectSquare(new RowColumn(3, 3));
       Assert.Equal(expectedField, game.FieldAsString());
 
     }
@@ -44,7 +45,7 @@ namespace MineSweeper.Tests
                         + "   1.\n"
                         + "   21\n"
                         + "     \n";
-      game.ProcessSquareSelection(new RowColumn(0, 4));
+      game.SelectSquare(new RowColumn(0, 4));
       Assert.Equal(expectedField, game.FieldAsString());
 
     }

--- a/MineSweeper.Tests/GameTests.cs
+++ b/MineSweeper.Tests/GameTests.cs
@@ -30,7 +30,7 @@ namespace MineSweeper.Tests
                         + "     \n"
                         + "   2 \n"
                         + "     \n";
-      game.SelectSquare(new RowColumn(3, 3));
+      game.ProcessSquareSelection(new RowColumn(3, 3));
       Assert.Equal(expectedField, game.FieldAsString());
 
     }
@@ -45,7 +45,7 @@ namespace MineSweeper.Tests
                         + "   1.\n"
                         + "   21\n"
                         + "     \n";
-      game.SelectSquare(new RowColumn(0, 4));
+      game.ProcessSquareSelection(new RowColumn(0, 4));
       Assert.Equal(expectedField, game.FieldAsString());
 
     }

--- a/MineSweeper.Tests/MineFieldTests.cs
+++ b/MineSweeper.Tests/MineFieldTests.cs
@@ -43,6 +43,11 @@ namespace MineSweeper.Tests
       Assert.Equal(5, field.Field[3, 1].SquareHintValue);
       Assert.Equal(0, field.Field[2, 2].SquareHintValue);
     }
+//     [Fact]
+//     public void SquaresHaveCorectSquareHintValueRandom()
+//     {
+// //inttegration test full reveal
+//     }
 
     private int NumberOfMinesInField(int rows, int columns, Square[,] field)
     {

--- a/MineSweeper/ConsoleImplementation/ConsoleOutput.cs
+++ b/MineSweeper/ConsoleImplementation/ConsoleOutput.cs
@@ -31,7 +31,7 @@ namespace MineSweeper.ConsoleImplementation
     {
       if (square.SquareType == SquareType.Safe)
       {
-        var squareSymbol = square.SquareHintValue > 0 ? (square.SquareHintValue.ToString()) : (" ");
+        var squareSymbol = square.SquareHintValue > 0 ? (square.SquareHintValue.ToString()) : (".");
         return squareSymbol;
       }
       else

--- a/MineSweeper/ConsoleImplementation/ConsoleOutput.cs
+++ b/MineSweeper/ConsoleImplementation/ConsoleOutput.cs
@@ -5,40 +5,9 @@ namespace MineSweeper.ConsoleImplementation
 {
   public class ConsoleOutput : IOutPut
   {
-    public void DisplayField(MineField field)
+    public void DisplayField(string field)
     {
-      Console.WriteLine(FieldAsString(field));
+      Console.WriteLine(field);
     }
-
-    public string FieldAsString(MineField mineField)
-    {
-      var printableField = new StringBuilder();
-
-      for (int i = 0; i < mineField.RowDimension; i++)
-      {
-        for (int j = 0; j < mineField.ColumnDimension; j++)
-        {
-          var squareSymbol = mineField.Field[i, j].Revealed ? (SquareAsString(mineField.Field[i, j])) : (" ");
-
-          printableField.Append(squareSymbol);
-
-        }
-        printableField.Append("\n");
-      }
-      return printableField.ToString();
-    }
-    public string SquareAsString(Square square)
-    {
-      if (square.SquareType == SquareType.Safe)
-      {
-        var squareSymbol = square.SquareHintValue > 0 ? (square.SquareHintValue.ToString()) : (".");
-        return squareSymbol;
-      }
-      else
-      {
-        return "*";
-      }
-    }
-
   }
 }

--- a/MineSweeper/GameCore/Game.cs
+++ b/MineSweeper/GameCore/Game.cs
@@ -48,9 +48,9 @@ namespace MineSweeper
         return "*";
       }
     }
-    public HashSet<RowColumn> FindEmptySquaresAdjacentToThisEmptySquare(RowColumn emptySquare, out bool FoundSquares)
+    public HashSet<RowColumn> FindEmptySquaresAdjacentToThisEmptySquare(RowColumn emptySquare, out bool hasEmptyNeighbours)
     {
-      FoundSquares = false;
+      hasEmptyNeighbours = false;
       HashSet<RowColumn> emptySquares = new HashSet<RowColumn> { emptySquare };
       HashSet<RowColumn> adjacentSquares = _field.GetNeighboursOfSquare(emptySquare.Row, emptySquare.Column);
       foreach (RowColumn index in adjacentSquares)
@@ -58,45 +58,24 @@ namespace MineSweeper
         if (_field.Field[index.Row, index.Column].SquareHintValue == 0)
         {
           emptySquares.Add(index);
-          FoundSquares = true;
+          hasEmptyNeighbours = true;
         }
       }
-
-      return emptySquares;
-    }
-    public HashSet<RowColumn> EmptySquareProcess(RowColumn emptySquare)
-    {
-      bool stillFindingSquares = false;
-      var newSquares = new HashSet<RowColumn>();
-      var emptySquares = FindEmptySquaresAdjacentToThisEmptySquare(emptySquare, out bool FoundSquares);
-      do
-      {
-        foreach (RowColumn square in emptySquares)
-        {
-          newSquares = FindEmptySquaresAdjacentToThisEmptySquare(square, out bool foundSquares);
-          stillFindingSquares = foundSquares;
-        }
-        emptySquares.UnionWith(newSquares);
-
-      } while (newSquares.Count != emptySquares.Count);
       return emptySquares;
     }
 
-    public void UpdateVisability(HashSet<RowColumn> emptySquares)
-    {
-      _revealed.UnionWith(emptySquares);
-      foreach (RowColumn emptySquare in emptySquares)
-      {
-        _revealed.UnionWith(_field.GetNeighboursOfSquare(emptySquare.Row, emptySquare.Column));
-      }
-    }
     public void ProcessSquareSelection(RowColumn selectedSquare)
     {
       if (_field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue == 0)
       {
-        var squaresToReveal = EmptySquareProcess(selectedSquare);
-        UpdateVisability(squaresToReveal);
+        RevealNeighboursOfEmptySquare(selectedSquare);
       }
+
+    }
+    public void RevealNeighboursOfEmptySquare(RowColumn selectedSquare)
+    {
+      _revealed.Add(selectedSquare);
+      _revealed.UnionWith(_field.GetNeighboursOfSquare(selectedSquare.Row, selectedSquare.Column));
     }
     public bool IsMine(RowColumn index)
     {

--- a/MineSweeper/GameCore/Game.cs
+++ b/MineSweeper/GameCore/Game.cs
@@ -67,16 +67,18 @@ namespace MineSweeper
     public HashSet<RowColumn> EmptySquareProcess(RowColumn emptySquare)
     {
       bool stillFindingSquares = false;
+      var newSquares = new HashSet<RowColumn>();
       var emptySquares = FindEmptySquaresAdjacentToThisEmptySquare(emptySquare, out bool FoundSquares);
       do
       {
         foreach (RowColumn square in emptySquares)
         {
-          emptySquares.UnionWith(FindEmptySquaresAdjacentToThisEmptySquare(square, out bool foundSquares));
+          newSquares = FindEmptySquaresAdjacentToThisEmptySquare(square, out bool foundSquares);
           stillFindingSquares = foundSquares;
         }
+        emptySquares.UnionWith(newSquares);
 
-      } while (stillFindingSquares);
+      } while (newSquares.Count != emptySquares.Count);
       return emptySquares;
     }
 
@@ -88,11 +90,12 @@ namespace MineSweeper
         _revealed.UnionWith(_field.GetNeighboursOfSquare(emptySquare.Row, emptySquare.Column));
       }
     }
-    public void ProcessSquare(RowColumn selectedSquare)
+    public void ProcessSquareSelection(RowColumn selectedSquare)
     {
       if (_field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue == 0)
       {
-        EmptySquareProcess(selectedSquare);
+        var squaresToReveal = EmptySquareProcess(selectedSquare);
+        UpdateVisability(squaresToReveal);
       }
     }
     public bool IsMine(RowColumn index)

--- a/MineSweeper/GameCore/Game.cs
+++ b/MineSweeper/GameCore/Game.cs
@@ -29,7 +29,7 @@ namespace MineSweeper
       {
         for (int j = 0; j < _field.ColumnDimension; j++)
         {
-          var squareSymbol = _revealed.Contains(new RowColumn(i,j)) ? (SquareAsString(_field.Field[i, j])) : (" ");
+          var squareSymbol = _revealed.Contains(new RowColumn(i, j)) ? (SquareAsString(_field.Field[i, j])) : (" ");
           printableField.Append(squareSymbol);
         }
         printableField.Append("\n");
@@ -48,7 +48,39 @@ namespace MineSweeper
         return "*";
       }
     }
+    //this is an infinite loop that won't do much fix in morning
+    public void ProcessTurn(RowColumn selectedSquare)
+    {
+      HashSet<RowColumn> squaresOfInterest = new HashSet<RowColumn>();
+      do
+      {
+        if (_field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue == 0)
+        {
+          HashSet<RowColumn> adjacentSquares = _field.GetNeighboursOfSquare(selectedSquare.Row, selectedSquare.Column);
+          _revealed.Add(selectedSquare);
+          _revealed.UnionWith(adjacentSquares);
+
+          foreach (RowColumn index in adjacentSquares)
+          {
+            if (_field.Field[index.Row, index.Column].SquareHintValue == 0)
+            {
+              squaresOfInterest.Add(index);
+            }
+
+          }
+        }
+
+      } while (squaresOfInterest.Count > 0);
 
 
+    }
+    public void UpdateVisability()
+    {
+
+    }
+    public bool IsMine(RowColumn index)
+    {
+      return SquareType.Mine == _field.Field[index.Row, index.Column].SquareType;
+    }
   }
 }

--- a/MineSweeper/GameCore/Game.cs
+++ b/MineSweeper/GameCore/Game.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace MineSweeper
 {
@@ -18,10 +19,36 @@ namespace MineSweeper
       return _field.Field;
     }
 
-    public bool IsMine(RowColumn index)
+    public static string FieldAsString(MineField mineField)
     {
-      return SquareType.Mine == _field.Field[index.Row, index.Column].SquareType;
+      var printableField = new StringBuilder();
+
+      for (int i = 0; i < mineField.RowDimension; i++)
+      {
+        for (int j = 0; j < mineField.ColumnDimension; j++)
+        {
+          var squareSymbol = mineField.Field[i, j].Revealed ? (SquareAsString(mineField.Field[i, j])) : (" ");
+
+          printableField.Append(squareSymbol);
+
+        }
+        printableField.Append("\n");
+      }
+      return printableField.ToString();
     }
+    public static string SquareAsString(Square square)
+    {
+      if (square.SquareType == SquareType.Safe)
+      {
+        var squareSymbol = square.SquareHintValue > 0 ? (square.SquareHintValue.ToString()) : (".");
+        return squareSymbol;
+      }
+      else
+      {
+        return "*";
+      }
+    }
+
 
   }
 }

--- a/MineSweeper/GameCore/Game.cs
+++ b/MineSweeper/GameCore/Game.cs
@@ -8,10 +8,12 @@ namespace MineSweeper
   public class Game
   {
     private MineField _field;
+    private HashSet<RowColumn> _revealed;
 
     public Game(MineField field)
     {
       _field = field;
+      _revealed = new HashSet<RowColumn>();
     }
 
     public Square[,] GetField()
@@ -19,18 +21,16 @@ namespace MineSweeper
       return _field.Field;
     }
 
-    public static string FieldAsString(MineField mineField)
+    public string FieldAsString()
     {
       var printableField = new StringBuilder();
 
-      for (int i = 0; i < mineField.RowDimension; i++)
+      for (int i = 0; i < _field.RowDimension; i++)
       {
-        for (int j = 0; j < mineField.ColumnDimension; j++)
+        for (int j = 0; j < _field.ColumnDimension; j++)
         {
-          var squareSymbol = mineField.Field[i, j].Revealed ? (SquareAsString(mineField.Field[i, j])) : (" ");
-
+          var squareSymbol = _revealed.Contains(new RowColumn(i,j)) ? (SquareAsString(_field.Field[i, j])) : (" ");
           printableField.Append(squareSymbol);
-
         }
         printableField.Append("\n");
       }

--- a/MineSweeper/GameCore/Game.cs
+++ b/MineSweeper/GameCore/Game.cs
@@ -48,7 +48,6 @@ namespace MineSweeper
         return "*";
       }
     }
-    //this is an infinite loop that won't do much fix in morning
     public void ProcessTurn(RowColumn selectedSquare)
     {
       HashSet<RowColumn> squaresOfInterest = new HashSet<RowColumn>();
@@ -59,21 +58,26 @@ namespace MineSweeper
           HashSet<RowColumn> adjacentSquares = _field.GetNeighboursOfSquare(selectedSquare.Row, selectedSquare.Column);
           _revealed.Add(selectedSquare);
           _revealed.UnionWith(adjacentSquares);
-
-          foreach (RowColumn index in adjacentSquares)
-          {
-            if (_field.Field[index.Row, index.Column].SquareHintValue == 0)
-            {
-              squaresOfInterest.Add(index);
-            }
-
-          }
+          squaresOfInterest.UnionWith(EmptySquareProcess(adjacentSquares));
         }
-
-      } while (squaresOfInterest.Count > 0);
-
-
+        _revealed.UnionWith(squaresOfInterest);
+      } while (!squaresOfInterest.IsSubsetOf(_revealed));
     }
+    public HashSet<RowColumn> EmptySquareProcess(HashSet<RowColumn> adjacentSquares)
+    {
+      _revealed.UnionWith(adjacentSquares);
+      HashSet<RowColumn> squaresOfInterest = new HashSet<RowColumn>();
+
+      foreach (RowColumn index in adjacentSquares)
+      {
+        if (_field.Field[index.Row, index.Column].SquareHintValue == 0)
+        {
+          squaresOfInterest.Add(index);
+        }
+      }
+      return squaresOfInterest;
+    }
+
     public void UpdateVisability()
     {
 

--- a/MineSweeper/GameCore/Game.cs
+++ b/MineSweeper/GameCore/Game.cs
@@ -63,7 +63,30 @@ namespace MineSweeper
       }
       return emptySquares;
     }
+    public void SelectSquare(RowColumn selectedSquare)
+    {
+      if (_field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue == 0)
+      {
+        RevealNeighboursOfEmptySquare(selectedSquare);
+        var neighboursOfSquare = FindEmptySquaresAdjacentToThisEmptySquare(selectedSquare, out bool foundMoreEmpty);
+        if (foundMoreEmpty)
+        {
+          foreach (RowColumn square in neighboursOfSquare)
+          {
+            RevealNeighboursOfEmptySquare(square);
+          }
+        }
 
+      }
+      if (_field.Field[selectedSquare.Row, selectedSquare.Column].SquareType == SquareType.Safe)
+      {
+        RevealSquare(selectedSquare);
+      }
+    }
+    public void RevealSquare(RowColumn selectedSquare)
+    {
+      _revealed.Add(selectedSquare);
+    }
     public void ProcessSquareSelection(RowColumn selectedSquare)
     {
       if (_field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue == 0)

--- a/MineSweeper/GameCore/Game.cs
+++ b/MineSweeper/GameCore/Game.cs
@@ -48,47 +48,21 @@ namespace MineSweeper
         return "*";
       }
     }
-    public HashSet<RowColumn> FindEmptySquaresAdjacentToThisEmptySquare(RowColumn emptySquare, out bool hasEmptyNeighbours)
-    {
-      hasEmptyNeighbours = false;
-      HashSet<RowColumn> emptySquares = new HashSet<RowColumn> { emptySquare };
-      HashSet<RowColumn> adjacentSquares = _field.GetNeighboursOfSquare(emptySquare.Row, emptySquare.Column);
-      foreach (RowColumn index in adjacentSquares)
-      {
-        if (_field.Field[index.Row, index.Column].SquareHintValue == 0)
-        {
-          emptySquares.Add(index);
-          hasEmptyNeighbours = true;
-        }
-      }
-      return emptySquares;
-    }
-    public void SelectSquare(RowColumn selectedSquare)
-    {
-      if (_field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue == 0)
-      {
-        RevealNeighboursOfEmptySquare(selectedSquare);
-        var neighboursOfSquare = FindEmptySquaresAdjacentToThisEmptySquare(selectedSquare, out bool foundMoreEmpty);
-        if (foundMoreEmpty)
-        {
-          foreach (RowColumn square in neighboursOfSquare)
-          {
-            RevealNeighboursOfEmptySquare(square);
-          }
-        }
 
-      }
-      if (_field.Field[selectedSquare.Row, selectedSquare.Column].SquareType == SquareType.Safe)
-      {
-        RevealSquare(selectedSquare);
-      }
-    }
     public void RevealSquare(RowColumn selectedSquare)
     {
       _revealed.Add(selectedSquare);
     }
     public void ProcessSquareSelection(RowColumn selectedSquare)
     {
+      if (_revealed.Contains(selectedSquare))
+      {
+        return;
+      }
+      if (_field.Field[selectedSquare.Row, selectedSquare.Column].SquareType != SquareType.Mine || _field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue != 0)
+      {
+        _revealed.Add(selectedSquare);
+      }
       if (_field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue == 0)
       {
         RevealNeighboursOfEmptySquare(selectedSquare);
@@ -97,8 +71,12 @@ namespace MineSweeper
     }
     public void RevealNeighboursOfEmptySquare(RowColumn selectedSquare)
     {
-      _revealed.Add(selectedSquare);
-      _revealed.UnionWith(_field.GetNeighboursOfSquare(selectedSquare.Row, selectedSquare.Column));
+      var neighbours = _field.GetNeighboursOfSquare(selectedSquare.Row, selectedSquare.Column);
+
+      foreach (RowColumn index in neighbours)
+      {
+        ProcessSquareSelection(index);
+      }
     }
     public bool IsMine(RowColumn index)
     {

--- a/MineSweeper/GameCore/Game.cs
+++ b/MineSweeper/GameCore/Game.cs
@@ -53,29 +53,29 @@ namespace MineSweeper
     {
       _revealed.Add(selectedSquare);
     }
-    public void ProcessSquareSelection(RowColumn selectedSquare)
+    public void ProcessReveal(RowColumn selectedSquare)
     {
       if (_revealed.Contains(selectedSquare))
       {
         return;
       }
-      if (_field.Field[selectedSquare.Row, selectedSquare.Column].SquareType != SquareType.Mine || _field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue != 0)
+      //make ternary
+      if (!IsMine(selectedSquare) || _field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue != 0)
       {
         _revealed.Add(selectedSquare);
       }
       if (_field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue == 0)
       {
-        RevealNeighboursOfEmptySquare(selectedSquare);
+        ProcessRevealOfNeighboursOfEmptySquare(selectedSquare);
       }
 
     }
-    public void RevealNeighboursOfEmptySquare(RowColumn selectedSquare)
+    public void ProcessRevealOfNeighboursOfEmptySquare(RowColumn selectedSquare)
     {
       var neighbours = _field.GetNeighboursOfSquare(selectedSquare.Row, selectedSquare.Column);
-
       foreach (RowColumn index in neighbours)
       {
-        ProcessSquareSelection(index);
+        ProcessReveal(index);
       }
     }
     public bool IsMine(RowColumn index)

--- a/MineSweeper/GameCore/Game.cs
+++ b/MineSweeper/GameCore/Game.cs
@@ -48,18 +48,16 @@ namespace MineSweeper
         return "*";
       }
     }
-
-    public void RevealSquare(RowColumn selectedSquare)
+    public void HandleSelectedSquare(RowColumn selectedSquare)
     {
-      _revealed.Add(selectedSquare);
-    }
-    public void ProcessReveal(RowColumn selectedSquare)
-    {
+      if (IsMine(selectedSquare))
+      {
+        FindAndRevealMines();
+      }
       if (_revealed.Contains(selectedSquare))
       {
         return;
       }
-      //make ternary
       if (!IsMine(selectedSquare) || _field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue != 0)
       {
         _revealed.Add(selectedSquare);
@@ -68,19 +66,32 @@ namespace MineSweeper
       {
         ProcessRevealOfNeighboursOfEmptySquare(selectedSquare);
       }
-
     }
     public void ProcessRevealOfNeighboursOfEmptySquare(RowColumn selectedSquare)
     {
       var neighbours = _field.GetNeighboursOfSquare(selectedSquare.Row, selectedSquare.Column);
       foreach (RowColumn index in neighbours)
       {
-        ProcessReveal(index);
+        HandleSelectedSquare(index);
       }
     }
     public bool IsMine(RowColumn index)
     {
       return SquareType.Mine == _field.Field[index.Row, index.Column].SquareType;
     }
+    private void FindAndRevealMines()
+    {
+      for (int row = 0; row < _field.RowDimension; row++)
+      {
+        for (int column = 0; column < _field.ColumnDimension; column++)
+        {
+          if (IsMine(new RowColumn(row, column)))
+          {
+            _revealed.Add(new RowColumn(row, column));
+          }
+        }
+      }
+    }
+
   }
 }

--- a/MineSweeper/GameCore/IOutPut.cs
+++ b/MineSweeper/GameCore/IOutPut.cs
@@ -2,6 +2,6 @@ namespace MineSweeper
 {
     public interface IOutPut
     {
-        void DisplayField(MineField field); 
+        void DisplayField(string field); 
     }
 }

--- a/MineSweeper/GameCore/MineField.cs
+++ b/MineSweeper/GameCore/MineField.cs
@@ -36,7 +36,7 @@ namespace MineSweeper
       {
         for (int column = 0; column < ColumnDimension; column++)
         {
-          Field[row, column] = new Square(SquareType.Safe, 0, false);
+          Field[row, column] = new Square(SquareType.Safe, 0);
         }
       }
     }

--- a/MineSweeper/GameCore/MineField.cs
+++ b/MineSweeper/GameCore/MineField.cs
@@ -24,11 +24,23 @@ namespace MineSweeper
     }
     private void InitializeField()
     {
+      FillFieldWithSquares();
       HashSet<RowColumn> mines = _minePositioning.GetMinePositions();
       PlaceMines(mines);
       SetSquareHintValues();
 
     }
+    private void FillFieldWithSquares()
+    {
+      for (int row = 0; row < RowDimension; row++)
+      {
+        for (int column = 0; column < ColumnDimension; column++)
+        {
+          Field[row, column] = new Square(SquareType.Safe, 0, false);
+        }
+      }
+    }
+
     private void PlaceMines(HashSet<RowColumn> mines)
     {
       foreach (RowColumn index in mines)
@@ -79,7 +91,6 @@ namespace MineSweeper
         }
       }
     }
-
 
 
 

--- a/MineSweeper/GameCore/RowColumn.cs
+++ b/MineSweeper/GameCore/RowColumn.cs
@@ -1,9 +1,9 @@
 namespace MineSweeper
 {
-  public struct RowColumn
+  public readonly struct RowColumn
   {
-    public int Row;
-    public int Column;
+    public readonly int Row;
+    public readonly int Column;
 
     public RowColumn(int row, int column)
     {

--- a/MineSweeper/GameCore/Square.cs
+++ b/MineSweeper/GameCore/Square.cs
@@ -1,9 +1,17 @@
 namespace MineSweeper
 {
-    public struct Square
+  public class Square
+  {
+    public SquareType SquareType;
+    public int SquareHintValue;
+    public bool Revealed;
+    public Square(SquareType squareType, int hintValue, bool revealed)
     {
-      public SquareType SquareType;
-      public int SquareHintValue;
-      public bool Revealed;
+      SquareType = squareType;
+      SquareHintValue = hintValue;
+      Revealed = revealed;
     }
+
+
+  }
 }

--- a/MineSweeper/GameCore/Square.cs
+++ b/MineSweeper/GameCore/Square.cs
@@ -4,12 +4,12 @@ namespace MineSweeper
   {
     public SquareType SquareType;
     public int SquareHintValue;
-    public bool Revealed;
-    public Square(SquareType squareType, int hintValue, bool revealed)
+    // public bool Revealed;
+    public Square(SquareType squareType, int hintValue) //bool revealed
     {
       SquareType = squareType;
       SquareHintValue = hintValue;
-      Revealed = revealed;
+      // Revealed = revealed;
     }
 
 

--- a/MineSweeper/GameCore/SquareType.cs
+++ b/MineSweeper/GameCore/SquareType.cs
@@ -4,7 +4,5 @@ namespace MineSweeper
   {
     Safe,
     Mine
-
-
   }
 }

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Error Handling
     }
 ```
 
-Clear Intent
+#### Clear Intent
 
 
 
@@ -150,5 +150,43 @@ namespace MineSweeper
         HashSet<RowColumn> GetMinePositions(int rowDimension, int columnDimension, int numberOfMines); 
     }
 }
+```
+
+OOP
+
+Who is responsible for if the square is revealed?
+
+As thing stand my square is a class with a hintvalue and a square type, it had a bool on it 'revealed. 
+
+- when i decide to reveal clues and print the boadr is it faster/better to look into the board, look into it's square obj and ask are you revealed?
+  or 
+
+- have the game know which squares it has revealed as a hashset of rowcolumn indexes and when it looks through the field go, is this one on my list?.
+
+  I feel like seperaet list to decide what is and isn't revealed is more OOP.
+
+  This might also serve me better for the future - when the game ends i want o show the positions of all the mines - but no all the clues.  
+
+```c#
+  public string FieldAsString()
+    {
+      var printableField = new StringBuilder();
+
+      for (int i = 0; i < _field.RowDimension; i++)
+      {
+        for (int j = 0; j < _field.ColumnDimension; j++)
+        {
+
+          var squareSymbol = _revealed.Contains(new RowColumn(i,j)) ? (SquareAsString(_field.Field[i, j])) : (" ");
+
+          // var squareSymbol = _field.Field[i, j].Revealed ? (SquareAsString(_field.Field[i, j])) : (" ");
+
+          printableField.Append(squareSymbol);
+
+        }
+        printableField.Append("\n");
+      }
+      return printableField.ToString();
+    }
 ```
 


### PR DESCRIPTION
Appropriate Clue reveal for
- reveal all mines and 'discovered' revealed squares upon loss (but not entire field)
-reveal safe square
-reveal all adjacent safe squares to 'empty' squares and any further adjacent empty squares 