### PR TITLE
Can flag suspect mines

### DIFF
--- a/MineSweeper.Tests/GameTests.cs
+++ b/MineSweeper.Tests/GameTests.cs
@@ -22,6 +22,7 @@ namespace MineSweeper.Tests
       // [Fact]
 
       // }
+      
     }
   }
 }

--- a/MineSweeper.Tests/IntegrationTests.cs
+++ b/MineSweeper.Tests/IntegrationTests.cs
@@ -3,9 +3,9 @@ using Xunit;
 
 namespace MineSweeper.Tests
 {
-    public class IntegrationTests
-    {
-           [Fact]
+  public class IntegrationTests
+  {
+    [Fact]
     public void CantLoseOnFirstClickMovesMineToTopLeftReCalculatesSquareHints()
     {
       var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(2, 2), new RowColumn(4, 4) });
@@ -70,7 +70,7 @@ namespace MineSweeper.Tests
     [Fact]
     public void BalloonsCluesOutAppropriately()
     {
-      var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0)});
+      var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0) });
       var mineField = new MineField(5, 5, 5, minePositioning);
       var game = new Game(mineField);
       var expectedField = " 1...\n"
@@ -96,6 +96,32 @@ namespace MineSweeper.Tests
                         + "    *\n";
       Assert.Equal(expectedField, game.FieldAsString());
     }
+    [Fact]
+    public void CanFlagSuspectMine()
+    {
+      var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(4, 4) });
+      var mineField = new MineField(5, 5, 5, minePositioning);
+      var game = new Game(mineField);
+      var expectedField = " 1...\n"
+                        + " 211.\n"
+                        + "   1.\n"
+                        + "   21\n"
+                        + "     \n";
+      game.HandleSelectedSquare(new RowColumn(0, 4));
+      Assert.Equal(expectedField, game.FieldAsString());
+
+      game.FlagSquare(new RowColumn(0, 0));
+      var expectedFlagField = "F1...\n"
+                            + " 211.\n"
+                            + "   1.\n"
+                            + "   21\n"
+                            + "     \n";
+
+      var actualFlagField = game.FieldAsString();
+      Assert.Equal(expectedFlagField, actualFlagField);
 
     }
+
+
+  }
 }

--- a/MineSweeper.Tests/SquareTests.cs
+++ b/MineSweeper.Tests/SquareTests.cs
@@ -12,7 +12,7 @@ namespace MineSweeper.Tests
       string mineSquare = Square.SquareAsString(aMineSquare);
       string safeSquare = Square.SquareAsString(aSafeSquare);
       Assert.Equal("*", mineSquare);
-      Assert.Equal("4", safeSquare);
+      Assert.Equal(" ", safeSquare);
     }
   }
 }

--- a/MineSweeper/GameCore/Game.cs
+++ b/MineSweeper/GameCore/Game.cs
@@ -8,12 +8,13 @@ namespace MineSweeper
   public class Game
   {
     private MineField _field;
-    private HashSet<RowColumn> _revealed;
+    // private HashSet<RowColumn> _revealed;
+    // private HashSet<RowColumn> _flagged;
 
     public Game(MineField field)
     {
       _field = field;
-      _revealed = new HashSet<RowColumn>();
+      // _revealed = new HashSet<RowColumn>();
     }
 
     public Square[,] GetField()
@@ -29,7 +30,7 @@ namespace MineSweeper
       {
         for (int j = 0; j < _field.ColumnDimension; j++)
         {
-          var squareSymbol = _revealed.Contains(new RowColumn(i, j)) ? (Square.SquareAsString(_field.Field[i, j])) : (" ");
+          var squareSymbol = _field.Field[i,j].IsRevealed ? (Square.SquareAsString(_field.Field[i,j])) : (" ");
           printableField.Append(squareSymbol);
         }
         printableField.Append("\n");
@@ -43,13 +44,13 @@ namespace MineSweeper
       {
         FindAndRevealMines();
       }
-      if (_revealed.Contains(selectedSquare))
+      if (_field.Field[selectedSquare.Row, selectedSquare.Column].IsRevealed)
       {
         return;
       }
       if (!IsMine(selectedSquare) || _field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue != 0)
       {
-        _revealed.Add(selectedSquare);
+        _field.Field[selectedSquare.Row, selectedSquare.Column].IsRevealed = true;
       }
       if (_field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue == 0)
       {
@@ -76,7 +77,8 @@ namespace MineSweeper
         {
           if (IsMine(new RowColumn(row, column)))
           {
-            _revealed.Add(new RowColumn(row, column));
+            // _revealed.Add(new RowColumn(row, column));
+            _field.Field[row,column].IsRevealed = true;
           }
         }
       }
@@ -92,6 +94,13 @@ namespace MineSweeper
         _field.MineHitOnFirstHitReArrange(selectedSquare);
         HandleSelectedSquare(selectedSquare);
       }
+    }
+
+    public void FlagSquare(RowColumn selectedSquare)
+    {
+      // _flagged.Add(selectedSquare);
+      _field.Field[selectedSquare.Row, selectedSquare.Column].IsFlagged = true;
+
     }
 
   }

--- a/MineSweeper/GameCore/Game.cs
+++ b/MineSweeper/GameCore/Game.cs
@@ -25,19 +25,19 @@ namespace MineSweeper
     public string FieldAsString()
     {
       var printableField = new StringBuilder();
-
       for (int i = 0; i < _field.RowDimension; i++)
       {
         for (int j = 0; j < _field.ColumnDimension; j++)
         {
-          var squareSymbol = _field.Field[i,j].IsRevealed ? (Square.SquareAsString(_field.Field[i,j])) : (" ");
-          printableField.Append(squareSymbol);
+      var squareSymbol = _field.Field[i, j].IsRevealed ? (Square.SquareAsString(_field.Field[i, j])) : (" ");
+          var symbolOnGrid = _field.Field[i,j].IsFlagged ? ("F") : (squareSymbol);
+          printableField.Append(symbolOnGrid);
         }
         printableField.Append("\n");
       }
       return printableField.ToString();
     }
-  
+
     public void HandleSelectedSquare(RowColumn selectedSquare)
     {
       if (IsMine(selectedSquare))
@@ -78,7 +78,7 @@ namespace MineSweeper
           if (IsMine(new RowColumn(row, column)))
           {
             // _revealed.Add(new RowColumn(row, column));
-            _field.Field[row,column].IsRevealed = true;
+            _field.Field[row, column].IsRevealed = true;
           }
         }
       }
@@ -95,7 +95,6 @@ namespace MineSweeper
         HandleSelectedSquare(selectedSquare);
       }
     }
-
     public void FlagSquare(RowColumn selectedSquare)
     {
       // _flagged.Add(selectedSquare);

--- a/MineSweeper/GameCore/Game.cs
+++ b/MineSweeper/GameCore/Game.cs
@@ -29,9 +29,7 @@ namespace MineSweeper
       {
         for (int j = 0; j < _field.ColumnDimension; j++)
         {
-      var squareSymbol = _field.Field[i, j].IsRevealed ? (Square.SquareAsString(_field.Field[i, j])) : (" ");
-          var symbolOnGrid = _field.Field[i,j].IsFlagged ? ("F") : (squareSymbol);
-          printableField.Append(symbolOnGrid);
+          printableField.Append(Square.SquareAsString(_field.Field[i,j]));
         }
         printableField.Append("\n");
       }

--- a/MineSweeper/GameCore/Square.cs
+++ b/MineSweeper/GameCore/Square.cs
@@ -15,14 +15,18 @@ namespace MineSweeper
     }
     public static string SquareAsString(Square square)
     {
-      if (square.SquareType == SquareType.Safe)
+      if (!square.IsRevealed && square.IsFlagged)
+      {
+        return "F";
+      }
+      if (square.IsRevealed && square.SquareType == SquareType.Safe)
       {
         var squareSymbol = square.SquareHintValue > 0 ? (square.SquareHintValue.ToString()) : (".");
         return squareSymbol;
       }
-      if (square.IsFlagged)
+      if (!square.IsRevealed)
       {
-        return "F";
+        return " ";
       }
       else
       {

--- a/MineSweeper/GameCore/Square.cs
+++ b/MineSweeper/GameCore/Square.cs
@@ -4,10 +4,14 @@ namespace MineSweeper
   {
     public SquareType SquareType;
     public int SquareHintValue;
+    public bool IsFlagged;
+    public bool IsRevealed;
     public Square(SquareType squareType, int hintValue)
     {
       SquareType = squareType;
       SquareHintValue = hintValue;
+      IsFlagged = false;
+      IsRevealed = false;
     }
     public static string SquareAsString(Square square)
     {
@@ -15,6 +19,10 @@ namespace MineSweeper
       {
         var squareSymbol = square.SquareHintValue > 0 ? (square.SquareHintValue.ToString()) : (".");
         return squareSymbol;
+      }
+      if (square.IsFlagged)
+      {
+        return "F";
       }
       else
       {

--- a/README.md
+++ b/README.md
@@ -208,19 +208,20 @@ As things stand my square is a class with a hintvalue and a square type, it had 
 - have the game know which squares it has revealed as a hashset of rowcolumn indexes and when it looks through the field go, is this one on my list?
 
   
+
 probably 'efficiency' isn't going to be what a decision comes down to because there is likely little difference. 
   What is more meaningful is  how my class and program read as a whole. 
-  
+
   I feel like seperaet list to decide what is and isn't revealed is maybe less OOP but more domain appropriate.
-  
+
   Either way has implications for other logic.
-  
+
   for instance to implement the 'can't lose on first hit' logic I will need to reassign a mine somewhere else on the field. with a square class, I change it's enum property, and then I wil have to recalculate its adjacent squareHintValues.
-  
+
   On the other hand if I return to the square struct I would new up a new square object and put it in.  and have to instantiaet new squares and insert them for the adjacent squres - this is based on my understanding of using a struct well or appropriately - to properly benefit from its value type it is idea if they are immutable. 
-  
+
   One attractive thing about the square class as it stands is I probably do wanta mutable object. I don't want to throw the whole game away because someone hit a mine / new it up again when the same thing could happen/ expensive resource wise - so I can manipulate the square (have the squaer type as something mutable / designed that way) or a struct and make new ones and put them in. 
-  
+
 - the struct might be preferable in the end because it's only in the instance that the first hit is a mine that I have reason to change anything about the squares (UNLESS I want the square to be responsible for if it is revealed as well)
 
 ```c#
@@ -262,4 +263,38 @@ to look at the field.
 Sometimes I manipulate the field directly, but yesterday when implemented the logic to 're shuffle' a mine in the instance of hitting a mine on the first selection, that logic in game called a func of MineFields, becaues I thought the field may be responsible for manipulating itself - but this created a dependency for my game class. I wanted my game class to have an object just passed into it and it to be relatively de coupled but I've just undermined this in the last day in a few places.
 
 I need to decide if it's ok for them to be tightly coupled like this. It's probably 'fine' for somethign small like this, but it cuts against what I had in mind.
+
+```C#
+  var squareSymbol = _revealed.Contains(new RowColumn(i, j)) ? (Square.SquareAsString(_field.Field[i, j])) : (" ");
+
+vs
+  
+   var squareSymbol = _field.Field[i,j].IsRevealed ? (Square.SquareAsString(_field.Field[i,j])) : (" ");
+```
+
+```C#
+  public void HandleSelectedSquare(RowColumn selectedSquare)
+    {
+      if (IsMine(selectedSquare))
+      {
+        FindAndRevealMines();
+      }
+      if _revealed.Contains(selectedSquare);
+      {
+        return;
+      }
+      if (!IsMine(selectedSquare) || _field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue != 0)
+      {
+        _revealed.Add(selectedSquare);
+      }
+      if (_field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue == 0)
+      {
+        ProcessRevealOfNeighboursOfEmptySquare(selectedSquare);
+      }
+    }
+```
+
+vs
+
+
 


### PR DESCRIPTION
can flag suspected mine and it is renedered as such.

tried out different approach to 'revealed' and 'flagged' - put these as properties on Square class.

I haven't fully refactored appropriately in other areas - for instance using the RowColumn indexes become pretty meaningless, or rather less meaningful and less uesful and difficult to read (strung along properties). 

I will revert to using the hashset list on the game for being responsible for what is revealed/ flagged/ representation of the values. Keep square as (or rather revert back to) just a square type (mine or safe) and hint value int. 