### PR TITLE
Make squares responsible again

### DIFF
--- a/MineSweeper.Tests/GameTests.cs
+++ b/MineSweeper.Tests/GameTests.cs
@@ -16,7 +16,7 @@ namespace MineSweeper.Tests
                         + "     \n"
                         + "     \n"
                         + "     \n";
-      Assert.Equal(expectedField, game.FieldAsString());
+      Assert.Equal(expectedField, game.GetCurrentField());
     }
     [Fact]
     public void RevealsAppropriateSquareHintValue()
@@ -30,7 +30,7 @@ namespace MineSweeper.Tests
                         + "   2 \n"
                         + "     \n";
       game.HandleSelectedSquare(new RowColumn(3, 3));
-      Assert.Equal(expectedField, game.FieldAsString());
+      Assert.Equal(expectedField, game.GetCurrentField());
     }
     [Fact]
     public void RevealsAppropriateSquareHintValueWhenEmptySquareSelected()
@@ -44,7 +44,7 @@ namespace MineSweeper.Tests
                         + "   21\n"
                         + "     \n";
       game.HandleSelectedSquare(new RowColumn(0, 4));
-      Assert.Equal(expectedField, game.FieldAsString());
+      Assert.Equal(expectedField, game.GetCurrentField());
     }
     [Fact]
     public void BalloonsCluesOutAppropriately()
@@ -58,7 +58,7 @@ namespace MineSweeper.Tests
                         + ".....\n"
                         + ".....\n";
       game.HandleSelectedSquare(new RowColumn(0, 4));
-      Assert.Equal(expectedField, game.FieldAsString());
+      Assert.Equal(expectedField, game.GetCurrentField());
     }
     [Fact]
     public void OnLossRevealsAllMinePositionsAndAlreadyUncoveredClues()
@@ -73,7 +73,7 @@ namespace MineSweeper.Tests
                         + "  *1.\n"
                         + "   21\n"
                         + "    *\n";
-      Assert.Equal(expectedField, game.FieldAsString());
+      Assert.Equal(expectedField, game.GetCurrentField());
     }
     [Fact]
     public void CanFlagSuspectMine()
@@ -87,7 +87,7 @@ namespace MineSweeper.Tests
                         + "   21\n"
                         + "     \n";
       game.HandleSelectedSquare(new RowColumn(0, 4));
-      Assert.Equal(expectedField, game.FieldAsString());
+      Assert.Equal(expectedField, game.GetCurrentField());
 
       game.FlagSquare(new RowColumn(0, 0));
       var expectedFlagField = "F1...\n"
@@ -96,7 +96,7 @@ namespace MineSweeper.Tests
                             + "   21\n"
                             + "     \n";
 
-      var actualFlagField = game.FieldAsString();
+      var actualFlagField = game.GetCurrentField();
       Assert.Equal(expectedFlagField, actualFlagField);
     }
   }

--- a/MineSweeper.Tests/IntegrationTests.cs
+++ b/MineSweeper.Tests/IntegrationTests.cs
@@ -17,7 +17,7 @@ namespace MineSweeper.Tests
                         + ".....\n"
                         + "...11\n"
                         + "...1 \n";
-      Assert.Equal(expectedField, game.FieldAsString());
+      Assert.Equal(expectedField, game.GetCurrentField());
     }
     [Fact]
     public void StilHasSameNumberOfMinesAfterFirstHitRearrange()

--- a/MineSweeper.Tests/IntegrationTests.cs
+++ b/MineSweeper.Tests/IntegrationTests.cs
@@ -25,25 +25,10 @@ namespace MineSweeper.Tests
       var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(2, 2), new RowColumn(4, 4) });
       var mineField = new MineField(5, 5, minePositioning);
       var game = new Game(mineField);
-      int numberOfMinesBeforeHit = NumberOfMinesInField(5, 5, mineField.Field);
+      int numberOfMinesBeforeHit = mineField.MineCount;
       game.ProcessFirstHit(new RowColumn(2, 2));
-      int numberOfMinesAfterHit = NumberOfMinesInField(5, 5, mineField.Field);
+      int numberOfMinesAfterHit = mineField.MineCount;
       Assert.Equal(numberOfMinesBeforeHit, numberOfMinesAfterHit);
-    }
-    private int NumberOfMinesInField(int rows, int columns, Square[,] field)
-    {
-      int actualNumberOfMinesInField = 0;
-      for (int i = 0; i < rows; i++)
-      {
-        for (int j = 0; j < columns; j++)
-        {
-          if (field[i, j].SquareType == SquareType.Mine)
-          {
-            actualNumberOfMinesInField++;
-          }
-        }
-      }
-      return actualNumberOfMinesInField;
     }
   }
 }

--- a/MineSweeper.Tests/MineFieldTests.cs
+++ b/MineSweeper.Tests/MineFieldTests.cs
@@ -20,8 +20,7 @@ namespace MineSweeper.Tests
     {
       var minePlacement = new RandomMinePositions(5, 5, 0);
       var field = new MineField(5, 5, minePlacement);
-      var actualNumberOfMinesInField = field.MineCount;
-      Assert.Equal(0, actualNumberOfMinesInField);
+      Assert.Equal(0, field.MineCount);
     }
 
     [Fact]
@@ -29,8 +28,7 @@ namespace MineSweeper.Tests
     {
       var minePlacement = new RandomMinePositions(5, 5, 25);
       var field = new MineField(5, 5, minePlacement);
-      int numberOfMinesOnField = field.MineCount;
-      Assert.Equal(25, numberOfMinesOnField);
+      Assert.Equal(25, field.MineCount);
     }
     // [Fact]
     // public void SquareHaveCorrectSquareHintValue()
@@ -42,25 +40,5 @@ namespace MineSweeper.Tests
     //   Assert.Equal(5, field.Field[3, 1].SquareHintValue);
     //   Assert.Equal(0, field.Field[2, 2].SquareHintValue);
     // }
-
-    // private int NumberOfMinesInField(int rows, int columns, Square[,] field)
-    // {
-    //   int actualNumberOfMinesInField = 0;
-    //   for (int i = 0; i < rows; i++)
-    //   {
-    //     for (int j = 0; j < columns; j++)
-    //     {
-    //       if (field[i, j].SquareType == SquareType.Mine)
-    //       {
-    //         actualNumberOfMinesInField++;
-    //       }
-    //     }
-    //   }
-    //   return actualNumberOfMinesInField;
-    // }
-
-
-
-
   }
 }

--- a/MineSweeper.Tests/MineFieldTests.cs
+++ b/MineSweeper.Tests/MineFieldTests.cs
@@ -30,15 +30,19 @@ namespace MineSweeper.Tests
       var field = new MineField(5, 5, minePlacement);
       Assert.Equal(25, field.MineCount);
     }
-    // [Fact]
-    // public void SquareHaveCorrectSquareHintValue()
-    // {
-    //   var minePlacement = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(0, 1), new RowColumn(0, 2), new RowColumn(0, 3), new RowColumn(0, 4), new RowColumn(1, 0), new RowColumn(2, 0), new RowColumn(3, 0), new RowColumn(4, 0), new RowColumn(4, 1), new RowColumn(4, 2), new RowColumn(4, 3), new RowColumn(4, 4), new RowColumn(1, 4), new RowColumn(2, 4), new RowColumn(3, 4) });
-    //   var field = new MineField(5, 5, minePlacement);
-    //   Assert.Equal(5, field.Field[1, 1].SquareHintValue);
-    //   Assert.Equal(3, field.Field[1, 2].SquareHintValue);
-    //   Assert.Equal(5, field.Field[3, 1].SquareHintValue);
-    //   Assert.Equal(0, field.Field[2, 2].SquareHintValue);
-    // }
+    [Fact]
+    public void SquareHintValuesAreAccuratelyCalculated()
+    {
+      var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(4, 4) });
+      var mineField = new MineField(5, 5, minePositioning);
+      var game = new Game(mineField);
+      var expectedField = " 1...\n"
+                        + " 211.\n"
+                        + "   1.\n"
+                        + "   21\n"
+                        + "     \n";
+      game.HandleSelectedSquare(new RowColumn(0, 4));
+      Assert.Equal(expectedField, game.GetCurrentField());
+    }
   }
 }

--- a/MineSweeper.Tests/MineFieldTests.cs
+++ b/MineSweeper.Tests/MineFieldTests.cs
@@ -20,7 +20,7 @@ namespace MineSweeper.Tests
     {
       var minePlacement = new RandomMinePositions(5,5,0);
       var field = new MineField(5, 5, minePlacement);
-      var actualNumberOfMinesInField = NumberOfMinesInField(5, 5, field.Field);
+      var actualNumberOfMinesInField = NumberOfMinesInField(5, 5, field.MineCount);
       Assert.Equal(0, actualNumberOfMinesInField);
     }
 

--- a/MineSweeper.Tests/MineFieldTests.cs
+++ b/MineSweeper.Tests/MineFieldTests.cs
@@ -9,56 +9,55 @@ namespace MineSweeper.Tests
     [Fact]
     public void MineFieldIsOfSpecifiedDimensions()
     {
-      var minePlacement = new RandomMinePositions(1,2,1);
+      var minePlacement = new RandomMinePositions(1, 2, 1);
       var field = new MineField(1, 2, minePlacement);
-      Assert.True(field.Field.GetLength(0) == 1);
-      Assert.True(field.Field.GetLength(1) == 2);
+      Assert.True(field.RowDimension == 1);
+      Assert.True(field.ColumnDimension == 2);
     }
 
     [Fact]
     public void CanMakeSafeField()
     {
-      var minePlacement = new RandomMinePositions(5,5,0);
+      var minePlacement = new RandomMinePositions(5, 5, 0);
       var field = new MineField(5, 5, minePlacement);
-      var actualNumberOfMinesInField = NumberOfMinesInField(5, 5, field.MineCount);
+      var actualNumberOfMinesInField = field.MineCount;
       Assert.Equal(0, actualNumberOfMinesInField);
     }
 
     [Fact]
     public void CanAlwaysAllocatePositionsForFullNumberOfMines()
     {
-      var minePlacement = new RandomMinePositions(5,5,25);
+      var minePlacement = new RandomMinePositions(5, 5, 25);
       var field = new MineField(5, 5, minePlacement);
-      int actualNumberOfMinesInField = NumberOfMinesInField(5, 5, field.Field);
+      int numberOfMinesOnField = field.MineCount;
+      Assert.Equal(25, numberOfMinesOnField);
+    }
+    // [Fact]
+    // public void SquareHaveCorrectSquareHintValue()
+    // {
+    //   var minePlacement = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(0, 1), new RowColumn(0, 2), new RowColumn(0, 3), new RowColumn(0, 4), new RowColumn(1, 0), new RowColumn(2, 0), new RowColumn(3, 0), new RowColumn(4, 0), new RowColumn(4, 1), new RowColumn(4, 2), new RowColumn(4, 3), new RowColumn(4, 4), new RowColumn(1, 4), new RowColumn(2, 4), new RowColumn(3, 4) });
+    //   var field = new MineField(5, 5, minePlacement);
+    //   Assert.Equal(5, field.Field[1, 1].SquareHintValue);
+    //   Assert.Equal(3, field.Field[1, 2].SquareHintValue);
+    //   Assert.Equal(5, field.Field[3, 1].SquareHintValue);
+    //   Assert.Equal(0, field.Field[2, 2].SquareHintValue);
+    // }
 
-      Assert.Equal(25, actualNumberOfMinesInField);
-    }
-    [Fact]
-    public void SquareHaveCorrectSquareHintValue()
-    {
-      var minePlacement = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(0, 1), new RowColumn(0, 2), new RowColumn(0, 3), new RowColumn(0, 4), new RowColumn(1, 0), new RowColumn(2, 0), new RowColumn(3, 0), new RowColumn(4, 0), new RowColumn(4, 1), new RowColumn(4, 2), new RowColumn(4, 3), new RowColumn(4, 4), new RowColumn(1, 4), new RowColumn(2, 4), new RowColumn(3, 4) });
-      var field = new MineField(5, 5, minePlacement);
-      Assert.Equal(5, field.Field[1, 1].SquareHintValue);
-      Assert.Equal(3, field.Field[1, 2].SquareHintValue);
-      Assert.Equal(5, field.Field[3, 1].SquareHintValue);
-      Assert.Equal(0, field.Field[2, 2].SquareHintValue);
-    }
-
-    private int NumberOfMinesInField(int rows, int columns, Square[,] field)
-    {
-      int actualNumberOfMinesInField = 0;
-      for (int i = 0; i < rows; i++)
-      {
-        for (int j = 0; j < columns; j++)
-        {
-          if (field[i, j].SquareType == SquareType.Mine)
-          {
-            actualNumberOfMinesInField++;
-          }
-        }
-      }
-      return actualNumberOfMinesInField;
-    }
+    // private int NumberOfMinesInField(int rows, int columns, Square[,] field)
+    // {
+    //   int actualNumberOfMinesInField = 0;
+    //   for (int i = 0; i < rows; i++)
+    //   {
+    //     for (int j = 0; j < columns; j++)
+    //     {
+    //       if (field[i, j].SquareType == SquareType.Mine)
+    //       {
+    //         actualNumberOfMinesInField++;
+    //       }
+    //     }
+    //   }
+    //   return actualNumberOfMinesInField;
+    // }
 
 
 

--- a/MineSweeper/GameCore/Game.cs
+++ b/MineSweeper/GameCore/Game.cs
@@ -4,16 +4,13 @@ using System.Text;
 
 namespace MineSweeper
 {
-  public class Game {
+  public class Game
+  {
     private readonly MineField _field;
-    private readonly HashSet<RowColumn> _revealed;
-    private readonly HashSet<RowColumn> _flagged;
 
     public Game(MineField field)
     {
       _field = field;
-      _revealed = new HashSet<RowColumn>();
-      _flagged = new HashSet<RowColumn>();
     }
 
     public Square[,] GetField()
@@ -28,16 +25,7 @@ namespace MineSweeper
       {
         for (int j = 0; j < _field.ColumnDimension; j++)
         {
-          if (_revealed.Contains(new RowColumn(i, j)))
-          {
-            printableField.Append(_field.Field[i,j].SquareAsString());
-            continue;
-          }
-          else
-          {
-            var value = !_flagged.Contains(new RowColumn(i, j)) ? " " : "F";
-            printableField.Append(value);
-          }
+          printableField.Append(_field.Field[i, j].SquareAsString());
         }
         printableField.Append("\n");
       }
@@ -50,13 +38,13 @@ namespace MineSweeper
       {
         FindAndRevealMines();
       }
-      if (_revealed.Contains(selectedSquare))
+      if (_field.Field[selectedSquare.Row, selectedSquare.Column].IsRevealed)
       {
         return;
       }
       if (!IsMine(selectedSquare) || _field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue != 0)
       {
-        _revealed.Add(selectedSquare);
+        _field.Field[selectedSquare.Row, selectedSquare.Column].IsRevealed = true;
       }
       if (_field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue == 0)
       {
@@ -81,9 +69,9 @@ namespace MineSweeper
       {
         for (int column = 0; column < _field.ColumnDimension; column++)
         {
-          if (IsMine(new RowColumn(row, column)))
+          if (_field.Field[row, column].SquareType == SquareType.Mine)
           {
-            _revealed.Add(new RowColumn(row, column));
+            _field.Field[row, column].IsRevealed = true;
           }
         }
       }
@@ -102,7 +90,7 @@ namespace MineSweeper
     }
     public void FlagSquare(RowColumn selectedSquare)
     {
-      _flagged.Add(selectedSquare);
+      _field.Field[selectedSquare.Row, selectedSquare.Column].IsFlagged = true;
     }
   }
 }

--- a/MineSweeper/GameCore/Game.cs
+++ b/MineSweeper/GameCore/Game.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 
 namespace MineSweeper
 {
@@ -13,40 +13,25 @@ namespace MineSweeper
       _field = field;
     }
 
-    public Square[,] GetField()
+    public string GetCurrentField()
     {
-      return _field.Field;
+      return this._field.FieldAsString();
     }
-
-    public string FieldAsString()
-    {
-      var printableField = new StringBuilder();
-      for (int i = 0; i < _field.RowDimension; i++)
-      {
-        for (int j = 0; j < _field.ColumnDimension; j++)
-        {
-          printableField.Append(_field.Field[i, j].SquareAsString());
-        }
-        printableField.Append("\n");
-      }
-      return printableField.ToString();
-    }
-
     public void HandleSelectedSquare(RowColumn selectedSquare)
     {
       if (IsMine(selectedSquare))
       {
         FindAndRevealMines();
       }
-      if (_field.Field[selectedSquare.Row, selectedSquare.Column].IsRevealed)
+      if (_field[selectedSquare].IsRevealed)
       {
         return;
       }
-      if (!IsMine(selectedSquare) || _field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue != 0)
+      if (!IsMine(selectedSquare) || _field[selectedSquare].SquareHintValue != 0)
       {
-        _field.Field[selectedSquare.Row, selectedSquare.Column].IsRevealed = true;
+        _field[selectedSquare].IsRevealed = true;
       }
-      if (_field.Field[selectedSquare.Row, selectedSquare.Column].SquareHintValue == 0)
+      if (_field[selectedSquare].SquareHintValue == 0)
       {
         RevealAllAssociatedAdjacentSquaresProcess(selectedSquare);
       }
@@ -61,19 +46,13 @@ namespace MineSweeper
     }
     public bool IsMine(RowColumn index)
     {
-      return SquareType.Mine == _field.Field[index.Row, index.Column].SquareType;
+      return SquareType.Mine == _field[index].SquareType;
     }
     private void FindAndRevealMines()
     {
-      for (int row = 0; row < _field.RowDimension; row++)
+      foreach (var square in _field.Where(square => square.SquareType == SquareType.Mine))
       {
-        for (int column = 0; column < _field.ColumnDimension; column++)
-        {
-          if (_field.Field[row, column].SquareType == SquareType.Mine)
-          {
-            _field.Field[row, column].IsRevealed = true;
-          }
-        }
+        square.IsRevealed = true;
       }
     }
     public void ProcessFirstHit(RowColumn selectedSquare)
@@ -90,7 +69,7 @@ namespace MineSweeper
     }
     public void FlagSquare(RowColumn selectedSquare)
     {
-      _field.Field[selectedSquare.Row, selectedSquare.Column].IsFlagged = true;
+      _field[selectedSquare].IsFlagged = true;
     }
   }
 }

--- a/MineSweeper/GameCore/MineField.cs
+++ b/MineSweeper/GameCore/MineField.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Text;
+using System.Linq;
 
 namespace MineSweeper
 {
@@ -9,6 +10,8 @@ namespace MineSweeper
     private readonly Square[,] _field;
     public int RowDimension => _field.GetLength(0);
     public int ColumnDimension => _field.GetLength(1);
+    public int MineCount => Coordinates().Where(IsMine).Count();
+
     private readonly IMinePositions _minePositioning;
     public MineField(int rowDimension, int columnDimension, IMinePositions minePositioning)
     {
@@ -32,7 +35,7 @@ namespace MineSweeper
     {
       foreach (var coord in Coordinates())
       {
-        _field[coord.Row, coord.Column] =  new Square(SquareType.Safe, 0);
+        _field[coord.Row, coord.Column] = new Square(SquareType.Safe, 0);
       }
     }
 
@@ -132,6 +135,12 @@ namespace MineSweeper
           yield return new RowColumn(row, column);
         }
       }
+    }
+
+
+   public bool IsMine(RowColumn index)
+    {
+      return SquareType.Mine == this[index].SquareType;
     }
 
     public IEnumerator<Square> GetEnumerator() => (IEnumerator<Square>)_field.GetEnumerator();

--- a/MineSweeper/GameCore/MineField.cs
+++ b/MineSweeper/GameCore/MineField.cs
@@ -30,12 +30,9 @@ namespace MineSweeper
     }
     private void FillFieldWithSquares()
     {
-      for (int row = 0; row < RowDimension; row++)
+      foreach (var coord in Coordinates())
       {
-        for (int column = 0; column < ColumnDimension; column++)
-        {
-          _field[row, column] = new Square(SquareType.Safe, 0);
-        }
+        _field[coord.Row, coord.Column] =  new Square(SquareType.Safe, 0);
       }
     }
 
@@ -43,7 +40,7 @@ namespace MineSweeper
     {
       foreach (RowColumn index in mines)
       {
-        _field[index.Row, index.Column].SquareType = SquareType.Mine;
+        this[index].SquareType = SquareType.Mine;
       }
     }
     public HashSet<RowColumn> GetNeighboursOfSquare(int row, int column)
@@ -122,6 +119,17 @@ namespace MineSweeper
             i++;
             j++;
           }
+        }
+      }
+    }
+
+    public IEnumerable<RowColumn> Coordinates()
+    {
+      for (int row = 0; row < RowDimension; row++)
+      {
+        for (int column = 0; column < ColumnDimension; column++)
+        {
+          yield return new RowColumn(row, column);
         }
       }
     }

--- a/MineSweeper/GameCore/MineField.cs
+++ b/MineSweeper/GameCore/MineField.cs
@@ -136,14 +136,11 @@ namespace MineSweeper
         }
       }
     }
-
-
-   public bool IsMine(RowColumn index)
+    public bool IsMine(RowColumn index)
     {
       return SquareType.Mine == this[index].SquareType;
     }
-
-    public IEnumerator<Square> GetEnumerator() => (IEnumerator<Square>)_field.GetEnumerator();
+    public IEnumerator<Square> GetEnumerator() => _field.Cast<Square>().GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
   }

--- a/MineSweeper/GameCore/MineField.cs
+++ b/MineSweeper/GameCore/MineField.cs
@@ -1,22 +1,25 @@
+using System.Collections;
 using System.Collections.Generic;
+using System.Text;
 
 namespace MineSweeper
 {
-  public class MineField
+  public class MineField : IEnumerable<Square>
   {
-    public Square[,] Field;
-    public int RowDimension;
-    public int ColumnDimension;
+    private readonly Square[,] _field;
+    public int RowDimension => _field.GetLength(0);
+    public int ColumnDimension => _field.GetLength(1);
     private readonly IMinePositions _minePositioning;
     public MineField(int rowDimension, int columnDimension, IMinePositions minePositioning)
     {
-      Field = new Square[rowDimension, columnDimension];
-      RowDimension = rowDimension;
-      ColumnDimension = columnDimension;
+      _field = new Square[rowDimension, columnDimension];
       _minePositioning = minePositioning;
       InitializeField();
 
     }
+
+    public Square this[RowColumn coord] => _field[coord.Row, coord.Column];
+
     private void InitializeField()
     {
       FillFieldWithSquares();
@@ -31,7 +34,7 @@ namespace MineSweeper
       {
         for (int column = 0; column < ColumnDimension; column++)
         {
-          Field[row, column] = new Square(SquareType.Safe, 0);
+          _field[row, column] = new Square(SquareType.Safe, 0);
         }
       }
     }
@@ -40,7 +43,7 @@ namespace MineSweeper
     {
       foreach (RowColumn index in mines)
       {
-        Field[index.Row, index.Column].SquareType = SquareType.Mine;
+        _field[index.Row, index.Column].SquareType = SquareType.Mine;
       }
     }
     public HashSet<RowColumn> GetNeighboursOfSquare(int row, int column)
@@ -58,7 +61,7 @@ namespace MineSweeper
     }
     private bool OutOfRange(RowColumn rowColumn)
     {
-      return rowColumn.Row < 0 || rowColumn.Row >= Field.GetLength(0) || rowColumn.Column < 0 || rowColumn.Column >= Field.GetLength(1);
+      return rowColumn.Row < 0 || rowColumn.Row >= _field.GetLength(0) || rowColumn.Column < 0 || rowColumn.Column >= _field.GetLength(1);
     }
     public int AdjacentMineCount(HashSet<RowColumn> neighbourList)
     {
@@ -66,7 +69,7 @@ namespace MineSweeper
 
       foreach (RowColumn index in neighbourList)
       {
-        if (Field[index.Row, index.Column].SquareType == SquareType.Mine)
+        if (_field[index.Row, index.Column].SquareType == SquareType.Mine)
         {
           count++;
         }
@@ -81,17 +84,30 @@ namespace MineSweeper
         {
           HashSet<RowColumn> neighbours = GetNeighboursOfSquare(row, column);
           int value = AdjacentMineCount(neighbours);
-          Field[row, column].SquareHintValue = value;
+          _field[row, column].SquareHintValue = value;
         }
       }
     }
+    public string FieldAsString()
+    {
+      var printableField = new StringBuilder();
+      for (int i = 0; i < this.RowDimension; i++)
+      {
+        for (int j = 0; j < this.ColumnDimension; j++)
+        {
+          printableField.Append(this._field[i, j].SquareAsString());
+        }
+        printableField.Append("\n");
+      }
+      return printableField.ToString();
+    }
     public void MineHitOnFirstHitReArrange(RowColumn firstHit)
     {
-      Field[firstHit.Row, firstHit.Column].SquareType = SquareType.Safe;
+      _field[firstHit.Row, firstHit.Column].SquareType = SquareType.Safe;
 
-      if (Field[0, 0].SquareType == SquareType.Safe)
+      if (_field[0, 0].SquareType == SquareType.Safe)
       {
-        Field[0, 0].SquareType = SquareType.Mine;
+        _field[0, 0].SquareType = SquareType.Mine;
         SetSquareHintValues();
         return;
       }
@@ -99,9 +115,9 @@ namespace MineSweeper
       {
         for (int j = 0; j < 1;)
         {
-          if (Field[i, j].SquareType == SquareType.Safe)
+          if (_field[i, j].SquareType == SquareType.Safe)
           {
-            Field[i, j].SquareType = SquareType.Mine;
+            _field[i, j].SquareType = SquareType.Mine;
             SetSquareHintValues();
             i++;
             j++;
@@ -109,5 +125,9 @@ namespace MineSweeper
         }
       }
     }
+
+    public IEnumerator<Square> GetEnumerator() => (IEnumerator<Square>)_field.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
   }
 }

--- a/MineSweeper/GameCore/Square.cs
+++ b/MineSweeper/GameCore/Square.cs
@@ -4,17 +4,29 @@ namespace MineSweeper
   {
     public SquareType SquareType;
     public int SquareHintValue;
+    public bool IsFlagged;
+    public bool IsRevealed;
     public Square(SquareType squareType, int hintValue)
     {
       SquareType = squareType;
       SquareHintValue = hintValue;
+      IsFlagged = false;
+      IsRevealed = false;
     }
     public string SquareAsString()
     {
-      if (this.SquareType == SquareType.Safe)
+      if (!this.IsRevealed && this.IsFlagged)
+      {
+        return "F";
+      }
+      if (this.IsRevealed && this.SquareType == SquareType.Safe)
       {
         var squareSymbol = this.SquareHintValue > 0 ? (this.SquareHintValue.ToString()) : (".");
         return squareSymbol;
+      }
+      if (!this.IsRevealed)
+      {
+        return " ";
       }
       else
       {

--- a/MineSweeper/GameCore/Square.cs
+++ b/MineSweeper/GameCore/Square.cs
@@ -13,6 +13,7 @@ namespace MineSweeper
       IsFlagged = false;
       IsRevealed = false;
     }
+
     public string SquareAsString()
     {
       if (!this.IsRevealed && this.IsFlagged)


### PR DESCRIPTION
Reverted to squares being responsible instead of tracking the hashsets of revealed and flagged in game. 
some functions in MineField have been re-jigged.
MineField can tell us how many mines are on it.