### PR TITLE
Square refactoring

### DIFF
--- a/MineSweeper.Tests/MineSweeper.Tests.csproj
+++ b/MineSweeper.Tests/MineSweeper.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp5.0.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/MineSweeper.Tests/SquareTests.cs
+++ b/MineSweeper.Tests/SquareTests.cs
@@ -9,10 +9,30 @@ namespace MineSweeper.Tests
     {
       Square aMineSquare = new Square(SquareType.Mine);
       Square aSafeSquare = new Square(SquareType.Four);
+      aMineSquare.IsRevealed = true;
+      aSafeSquare.IsRevealed = true;
       string mineSquare = aMineSquare.SquareAsString();
       string safeSquare = aSafeSquare.SquareAsString();
       Assert.Equal("*", mineSquare);
       Assert.Equal("4", safeSquare);
+    }
+    [Fact]
+    public void ASquareThatIsFlaggedThatIsRevealedCanDisplayItsClueValue()
+    {
+      var aSafeSquare = new Square(SquareType.Four);
+      aSafeSquare.IsRevealed = true;
+      aSafeSquare.IsFlagged = true;
+      string safeSquare = aSafeSquare.SquareAsString();
+      Assert.Equal("4", safeSquare);
+    }
+    [Fact]
+    public void AMineWillBeRepresentedAsMineEvenIfFlaggedWhenItIsRevealed()
+    {
+      var aMineSquare = new Square(SquareType.Mine);
+      aMineSquare.IsRevealed = true;
+      aMineSquare.IsFlagged = true;
+      string mineSquare = aMineSquare.SquareAsString();
+      Assert.Equal("*", mineSquare);
     }
   }
 }

--- a/MineSweeper.Tests/SquareTests.cs
+++ b/MineSweeper.Tests/SquareTests.cs
@@ -7,8 +7,8 @@ namespace MineSweeper.Tests
     [Fact]
     public void CanReprsentSelfAsString()
     {
-      Square aMineSquare = new Square(SquareType.Mine, 4);
-      Square aSafeSquare = new Square(SquareType.Safe, 4);
+      Square aMineSquare = new Square(SquareType.Mine);
+      Square aSafeSquare = new Square(SquareType.Four);
       string mineSquare = aMineSquare.SquareAsString();
       string safeSquare = aSafeSquare.SquareAsString();
       Assert.Equal("*", mineSquare);

--- a/MineSweeper/GameCore/Game.cs
+++ b/MineSweeper/GameCore/Game.cs
@@ -29,11 +29,11 @@ namespace MineSweeper
       {
         return;
       }
-      if (!IsMine(selectedSquare) || _field[selectedSquare].SquareHintValue != 0)
+      if (!IsMine(selectedSquare) || _field[selectedSquare].SquareType != 0)
       {
         _field[selectedSquare].IsRevealed = true;
       }
-      if (_field[selectedSquare].SquareHintValue == 0)
+      if (_field[selectedSquare].SquareType == 0)
       {
         RevealAllAssociatedAdjacentSquaresProcess(selectedSquare);
       }

--- a/MineSweeper/GameCore/MineField.cs
+++ b/MineSweeper/GameCore/MineField.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using System.Linq;
+using System;
 
 namespace MineSweeper
 {
@@ -35,7 +36,7 @@ namespace MineSweeper
     {
       foreach (var coord in Coordinates())
       {
-        _field[coord.Row, coord.Column] = new Square(SquareType.Safe, 0);
+        _field[coord.Row, coord.Column] = new Square(SquareType.Zero);
       }
     }
 
@@ -82,9 +83,12 @@ namespace MineSweeper
       {
         for (int column = 0; column < ColumnDimension; column++)
         {
-          var neighbours = GetNeighboursOfSquare(row, column);
-          int value = AdjacentMineCount(neighbours);
-          _field[row, column].SquareHintValue = value;
+          if (_field[row, column].SquareType != SquareType.Mine)
+          {
+            var neighbours = GetNeighboursOfSquare(row, column);
+            int value = AdjacentMineCount(neighbours);
+            _field[row, column].SquareType = (SquareType)value;
+          }
         }
       }
     }

--- a/MineSweeper/GameCore/Square.cs
+++ b/MineSweeper/GameCore/Square.cs
@@ -3,13 +3,11 @@ namespace MineSweeper
   public class Square
   {
     public SquareType SquareType;
-    public int SquareHintValue;
     public bool IsFlagged;
     public bool IsRevealed;
-    public Square(SquareType squareType, int hintValue)
+    public Square(SquareType squareType)
     {
       SquareType = squareType;
-      SquareHintValue = hintValue;
       IsFlagged = false;
       IsRevealed = false;
     }
@@ -20,9 +18,9 @@ namespace MineSweeper
       {
         return "F";
       }
-      if (this.IsRevealed && this.SquareType == SquareType.Safe)
+      if (this.IsRevealed && this.SquareType != SquareType.Mine)
       {
-        var squareSymbol = this.SquareHintValue > 0 ? (this.SquareHintValue.ToString()) : (".");
+        var squareSymbol = this.SquareType > 0 ? (this.SquareType.ToString()) : (".");
         return squareSymbol;
       }
       if (!this.IsRevealed)

--- a/MineSweeper/GameCore/Square.cs
+++ b/MineSweeper/GameCore/Square.cs
@@ -14,23 +14,25 @@ namespace MineSweeper
 
     public string SquareAsString()
     {
-      if (!this.IsRevealed && this.IsFlagged)
+      var unrevealedSymbol = this.IsFlagged ? "F" : " ";
+      return this.IsRevealed ? this.GetSquareSymbol() : unrevealedSymbol;
+    }
+  public string GetSquareSymbol()
+    {
+      return SquareType switch
       {
-        return "F";
-      }
-      if (this.IsRevealed && this.SquareType != SquareType.Mine)
-      {
-        var squareSymbol = this.SquareType > 0 ? (this.SquareType.ToString()) : (".");
-        return squareSymbol;
-      }
-      if (!this.IsRevealed)
-      {
-        return " ";
-      }
-      else
-      {
-        return "*";
-      }
+        SquareType.Zero => ".",
+        SquareType.One => "1",
+        SquareType.Two => "2",
+        SquareType.Three => "3",
+        SquareType.Four => "4",
+        SquareType.Five => "5",
+        SquareType.Six => "6",
+        SquareType.Seven => "7",
+        SquareType.Eight => "8",
+        SquareType.Mine => "*",
+        _ => " "
+      };
     }
   }
 }

--- a/MineSweeper/GameCore/Square.cs
+++ b/MineSweeper/GameCore/Square.cs
@@ -11,11 +11,10 @@ namespace MineSweeper
       IsFlagged = false;
       IsRevealed = false;
     }
-
     public string SquareAsString()
     {
-      var unrevealedSymbol = this.IsFlagged ? "F" : " ";
-      return this.IsRevealed ? this.GetSquareSymbol() : unrevealedSymbol;
+      var nonRevealedSymbol = this.IsFlagged ? "F" : " ";
+      return this.IsRevealed ? this.GetSquareSymbol() : nonRevealedSymbol;
     }
   public string GetSquareSymbol()
     {
@@ -31,7 +30,7 @@ namespace MineSweeper
         SquareType.Seven => "7",
         SquareType.Eight => "8",
         SquareType.Mine => "*",
-        _ => " "
+        // _ => " "
       };
     }
   }

--- a/MineSweeper/GameCore/SquareType.cs
+++ b/MineSweeper/GameCore/SquareType.cs
@@ -2,7 +2,16 @@ namespace MineSweeper
 {
   public enum SquareType
   {
-    Safe,
+    Zero = 0,
+    One,
+    Two,
+    Three,
+    Four,
+    Five,
+    Six,
+    Seven,
+    Eight,
     Mine
+
   }
 }

--- a/MineSweeper/GameCore/SquareType.cs
+++ b/MineSweeper/GameCore/SquareType.cs
@@ -12,6 +12,5 @@ namespace MineSweeper
     Seven,
     Eight,
     Mine
-
   }
 }

--- a/MineSweeper/MineSweeper.csproj
+++ b/MineSweeper/MineSweeper.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp5.0.0</TargetFramework>
+
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Removed property int SquareHintValue.
This property was a bit ambiguous - for instance it plays no role for a Square that is a mine so should it be part of a Square? probably not.
What I've gone with is something I initially tried but abandoned for initial readability (which I now think is fine readability wise)
the SquareType enum now represents the cell type and it's value, eg Zero has no adjacent mines, Two has two adjacent mines up until Eight, SquareType.Mine is a mine. 

This has allowed me to remove a redundant field and I don't think it's sacrificed readability.

Refactored how Square represents itself as a string and wrote some appropriate tests - for instance to check that if a Square is both flagged and revealed it will appropriately reveal the squares value, if a mine is flagged but also revealed it will represent the mine symbol - this is important to check because if a mine is flagged correctly by a player but they hit a mine elsewhere it needs to reveal this mine upon loss. 