### PR TITLE
Errors

### DIFF
--- a/MineSweeper.Tests/GameTests.cs
+++ b/MineSweeper.Tests/GameTests.cs
@@ -99,5 +99,14 @@ namespace MineSweeper.Tests
       var actualFlagField = game.GetCurrentField();
       Assert.Equal(expectedFlagField, actualFlagField);
     }
+    [Fact]
+    public void ShouldNotThrowIndexOutOfRange()
+    {
+      var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0) });
+      var mineField = new MineField(3, 3, minePositioning);
+      var game = new Game(mineField);
+      game.HandleSelectedSquare(new RowColumn(6, 6));
+      //write an assert does not throw
+    }
   }
 }

--- a/MineSweeper.Tests/MineFieldTests.cs
+++ b/MineSweeper.Tests/MineFieldTests.cs
@@ -14,7 +14,13 @@ namespace MineSweeper.Tests
       Assert.True(field.RowDimension == 1);
       Assert.True(field.ColumnDimension == 2);
     }
-
+    [Fact]
+    public void MineFieldThatReceievesInvalidArgsThrowsArgumentException()
+    {
+      var minePlacement = new RandomMinePositions(0, 0, 0);
+      var ex = Assert.Throws<System.ArgumentException>(() => new MineField(0, 0, minePlacement));
+      Assert.Equal("row and column dimensions are below minimum usable value", ex.Message);
+    }
     [Fact]
     public void CanMakeSafeField()
     {
@@ -26,7 +32,7 @@ namespace MineSweeper.Tests
     [Fact]
     public void CanAlwaysAllocatePositionsForFullNumberOfMines()
     {
-      var minePlacement = new RandomMinePositions(5,5, 25);
+      var minePlacement = new RandomMinePositions(5, 5, 25);
       var field = new MineField(5, 5, minePlacement);
       Assert.Equal(25, field.MineCount);
     }

--- a/MineSweeper.Tests/MineFieldTests.cs
+++ b/MineSweeper.Tests/MineFieldTests.cs
@@ -55,10 +55,8 @@ namespace MineSweeper.Tests
       var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(5, 4) });
       var mineField = new MineField(5, 5, minePositioning);
       var game = new Game(mineField);
-      var ex = Assert.Throws<System.Exception>(() => new MineField(0, 0, minePositioning));
+      var ex = Assert.Throws<Exception>(() => new MineField(0, 0, minePositioning));
       Assert.Equal("Mine list contains elements greater than field array dimensions", ex.Message);
-
     }
-
   }
 }

--- a/MineSweeper.Tests/MineFieldTests.cs
+++ b/MineSweeper.Tests/MineFieldTests.cs
@@ -9,16 +9,16 @@ namespace MineSweeper.Tests
     [Fact]
     public void MineFieldIsOfSpecifiedDimensions()
     {
-      var minePlacement = new RandomMinePositions(1, 2, 1);
-      var field = new MineField(1, 2, minePlacement);
-      Assert.True(field.RowDimension == 1);
+      var minePlacement = new RandomMinePositions(2, 2, 1);
+      var field = new MineField(2, 2, minePlacement);
+      Assert.True(field.RowDimension == 2);
       Assert.True(field.ColumnDimension == 2);
     }
     [Fact]
     public void MineFieldThatReceievesInvalidArgsThrowsArgumentException()
     {
       var minePlacement = new RandomMinePositions(0, 0, 0);
-      var ex = Assert.Throws<System.ArgumentException>(() => new MineField(0, 0, minePlacement));
+      var ex = Assert.Throws<ArgumentException>(() => new MineField(0, 0, minePlacement));
       Assert.Equal("row and column dimensions are below minimum usable value", ex.Message);
     }
     [Fact]
@@ -53,9 +53,7 @@ namespace MineSweeper.Tests
     public void ThrowsExceptionIfSetMinesHasAnOutOfIndexItem()
     {
       var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(5, 4) });
-      var mineField = new MineField(5, 5, minePositioning);
-      var game = new Game(mineField);
-      var ex = Assert.Throws<Exception>(() => new MineField(0, 0, minePositioning));
+      var ex = Assert.Throws<Exception>(() => new MineField(3, 3, minePositioning));
       Assert.Equal("Mine list contains elements greater than field array dimensions", ex.Message);
     }
   }

--- a/MineSweeper.Tests/MineFieldTests.cs
+++ b/MineSweeper.Tests/MineFieldTests.cs
@@ -28,7 +28,6 @@ namespace MineSweeper.Tests
       var field = new MineField(5, 5, minePlacement);
       Assert.Equal(0, field.MineCount);
     }
-
     [Fact]
     public void CanAlwaysAllocatePositionsForFullNumberOfMines()
     {
@@ -50,5 +49,16 @@ namespace MineSweeper.Tests
       game.HandleSelectedSquare(new RowColumn(0, 4));
       Assert.Equal(expectedField, game.GetCurrentField());
     }
+    [Fact]
+    public void ThrowsExceptionIfSetMinesHasAnOutOfIndexItem()
+    {
+      var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(5, 4) });
+      var mineField = new MineField(5, 5, minePositioning);
+      var game = new Game(mineField);
+      var ex = Assert.Throws<System.Exception>(() => new MineField(0, 0, minePositioning));
+      Assert.Equal("Mine list contains elements greater than field array dimensions", ex.Message);
+
+    }
+
   }
 }

--- a/MineSweeper.Tests/MineFieldTests.cs
+++ b/MineSweeper.Tests/MineFieldTests.cs
@@ -53,7 +53,7 @@ namespace MineSweeper.Tests
     public void ThrowsExceptionIfSetMinesHasAnOutOfIndexItem()
     {
       var minePositioning = new SetMinePositions(new HashSet<RowColumn> { new RowColumn(0, 0), new RowColumn(2, 2), new RowColumn(5, 4) });
-      var ex = Assert.Throws<Exception>(() => new MineField(3, 3, minePositioning));
+      var ex = Assert.Throws<ArgumentException>(() => new MineField(3, 3, minePositioning));
       Assert.Equal("Mine list contains elements greater than field array dimensions", ex.Message);
     }
   }

--- a/MineSweeper.Tests/MineFieldTests.cs
+++ b/MineSweeper.Tests/MineFieldTests.cs
@@ -26,7 +26,7 @@ namespace MineSweeper.Tests
     [Fact]
     public void CanAlwaysAllocatePositionsForFullNumberOfMines()
     {
-      var minePlacement = new RandomMinePositions(5, 5, 25);
+      var minePlacement = new RandomMinePositions(5,5, 25);
       var field = new MineField(5, 5, minePlacement);
       Assert.Equal(25, field.MineCount);
     }

--- a/MineSweeper.Tests/RandomMinePositionsTests.cs
+++ b/MineSweeper.Tests/RandomMinePositionsTests.cs
@@ -12,9 +12,6 @@ namespace MineSweeper.Tests
       var ex = Assert.Throws<System.ArgumentException>(() => minePositions.GetMinePositions());
 
       Assert.Equal("numberOfMines exceeds array dimensions (Parameter '10')", ex.Message);
-
     }
   }
-
-
 }

--- a/MineSweeper.Tests/SquareTests.cs
+++ b/MineSweeper.Tests/SquareTests.cs
@@ -7,8 +7,8 @@ namespace MineSweeper.Tests
     [Fact]
     public void CanReprsentSelfAsString()
     {
-      Square aMineSquare = new Square(SquareType.Mine);
-      Square aSafeSquare = new Square(SquareType.Four);
+      var aMineSquare = new Square(SquareType.Mine);
+      var aSafeSquare = new Square(SquareType.Four);
       aMineSquare.IsRevealed = true;
       aSafeSquare.IsRevealed = true;
       string mineSquare = aMineSquare.SquareAsString();

--- a/MineSweeper/ConsoleImplementation/ConsoleInput.cs
+++ b/MineSweeper/ConsoleImplementation/ConsoleInput.cs
@@ -5,48 +5,67 @@ namespace MineSweeper.ConsoleImplementation
 {
   public class ConsoleInput : IUserInput
   {
+    //does this need to be a property?
+    public int SquareDimensions;
+    public RowColumn SquareSelection;
+    public void Read() => Console.ReadLine();
+
     public string ReadInput(string askThis)
     {
       Console.WriteLine(askThis);
       return Console.ReadLine();
     }
-    public int SquareDimensions;
-    public RowColumn SquareSelection;
-    public void Read() => Console.ReadLine();
-
-    public void SetRange()
+    public void GetValidDimensions()
     {
-      PromptDimensions();
+      var userInput = "";
+      do
+      {
+        Console.WriteLine("Enter dimensions you want for your field (bw 3-30)");
+        userInput = Console.ReadLine();
+        try
+        {
+          IsValidDimension(userInput);
+          SquareDimensions = int.Parse(userInput);
+        }
+        catch (FormatException)
+        {
+          Console.WriteLine("Please enter a number");
+        }
+      } while (!IsValidDimension(userInput));
     }
-    public void PromptDimensions()
-    {
-      Console.WriteLine("Enter dimensions you want for your field");
-      var userInput = Console.ReadLine();
-
-      // if (CheckInput(userInput))
-      // {
-        SquareDimensions = int.Parse(userInput);
-        return;
-      // }
-      // while (!CheckInput(userInput)) ;
-    }
-    // // public void GetValidInput(string userInput)
-    // // {
-    // //   Console.WriteLine("dimensions must be between 3 and 30");
-    // //   CheckInput(userInput);
-    // //   userInput = Console.ReadLine();
-    // // }
-
-    public static bool CheckInput(string input)
+    public static bool IsValidDimension(string input)
     {
       int.TryParse(input, out int number);
       return number >= 3 && number < 30;
     }
+    public void GetValidSquareSelection()
+    {
+      do
+      {
+        try
+        {
+          ParseInputToRowColumn();
+        }
+        catch (IndexOutOfRangeException)
+        { }
+      }
+      while ();
+    }
     public RowColumn ParseInputToRowColumn()
     {
-      var input = Console.ReadLine();
-      var chars = input.Split(" ", StringSplitOptions.None);
-      return new RowColumn(int.Parse(chars[0]), int.Parse(chars[1]));
+      while(!IsValidRowColInput(chars))
+      {
+        var input = Console.ReadLine();
+        var chars = input.Split(" ", StringSplitOptions.None);
+        try
+        {
+          return new RowColumn(int.Parse(chars[0]), int.Parse(chars[1]));
+        }
+        catch (IndexOutOfRangeException)
+        {
+        }
+      }
     }
+    public static bool IsValidRowColInput(string[] chars) => chars.Length == 2;
   }
 }

--- a/MineSweeper/ConsoleImplementation/ConsoleInput.cs
+++ b/MineSweeper/ConsoleImplementation/ConsoleInput.cs
@@ -5,19 +5,11 @@ namespace MineSweeper.ConsoleImplementation
 {
   public class ConsoleInput : IUserInput
   {
-    //does this need to be a property?
-    public int SquareDimensions;
-    public RowColumn SquareSelection;
     public void Read() => Console.ReadLine();
-
-    public string ReadInput(string askThis)
+    public int GetValidDimensions()
     {
-      Console.WriteLine(askThis);
-      return Console.ReadLine();
-    }
-    public void GetValidDimensions()
-    {
-      var userInput = "";
+      int squareDimensions = 0;
+      string userInput;
       do
       {
         Console.WriteLine("Enter dimensions you want for your field (bw 3-30)");
@@ -25,13 +17,14 @@ namespace MineSweeper.ConsoleImplementation
         try
         {
           IsValidDimension(userInput);
-          SquareDimensions = int.Parse(userInput);
+          squareDimensions = int.Parse(userInput);
         }
         catch (FormatException)
         {
           Console.WriteLine("Please enter a number");
         }
       } while (!IsValidDimension(userInput));
+      return squareDimensions;
     }
     public static bool IsValidDimension(string input)
     {

--- a/MineSweeper/ConsoleImplementation/ConsoleInput.cs
+++ b/MineSweeper/ConsoleImplementation/ConsoleInput.cs
@@ -37,11 +37,11 @@ namespace MineSweeper.ConsoleImplementation
     // //   userInput = Console.ReadLine();
     // // }
 
-    // public static bool CheckInput(string input)
-    // {
-    //   int.TryParse(input, out int number);
-    //   return number >= 3 && number < 30;
-    // }
+    public static bool CheckInput(string input)
+    {
+      int.TryParse(input, out int number);
+      return number >= 3 && number < 30;
+    }
     public RowColumn ParseInputToRowColumn()
     {
       var input = Console.ReadLine();

--- a/MineSweeper/ConsoleImplementation/ConsoleInput.cs
+++ b/MineSweeper/ConsoleImplementation/ConsoleInput.cs
@@ -30,18 +30,18 @@ namespace MineSweeper.ConsoleImplementation
       // }
       // while (!CheckInput(userInput)) ;
     }
-    public void GetValidInput(string userInput)
-    {
-      Console.WriteLine("dimensions must be between 3 and 30");
-      CheckInput(userInput);
-      userInput = Console.ReadLine();
-    }
+    // // public void GetValidInput(string userInput)
+    // // {
+    // //   Console.WriteLine("dimensions must be between 3 and 30");
+    // //   CheckInput(userInput);
+    // //   userInput = Console.ReadLine();
+    // // }
 
-    public static bool CheckInput(string input)
-    {
-      int.TryParse(input, out int number);
-      return number >= 3 && number < 30;
-    }
+    // public static bool CheckInput(string input)
+    // {
+    //   int.TryParse(input, out int number);
+    //   return number >= 3 && number < 30;
+    // }
     public RowColumn ParseInputToRowColumn()
     {
       var input = Console.ReadLine();

--- a/MineSweeper/ConsoleImplementation/ConsoleInput.cs
+++ b/MineSweeper/ConsoleImplementation/ConsoleInput.cs
@@ -5,15 +5,18 @@ namespace MineSweeper.ConsoleImplementation
 {
   public class ConsoleInput : IUserInput
   {
-    public void Read() => Console.ReadLine();
+    public string ReadInput(string askThis)
+    {
+      Console.WriteLine(askThis);
+      return Console.ReadLine();
+    }
     public int GetValidDimensions()
     {
       int squareDimensions = 0;
       string userInput;
       do
       {
-        Console.WriteLine("Enter dimensions you want for your field (bw 3-30)");
-        userInput = Console.ReadLine();
+        userInput = ReadInput("Enter dimensions you want for your field (bw 3 - 30");
         try
         {
           IsValidDimension(userInput);

--- a/MineSweeper/ConsoleImplementation/ConsoleInput.cs
+++ b/MineSweeper/ConsoleImplementation/ConsoleInput.cs
@@ -38,34 +38,13 @@ namespace MineSweeper.ConsoleImplementation
       int.TryParse(input, out int number);
       return number >= 3 && number < 30;
     }
-    public void GetValidSquareSelection()
-    {
-      do
-      {
-        try
-        {
-          ParseInputToRowColumn();
-        }
-        catch (IndexOutOfRangeException)
-        { }
-      }
-      while ();
-    }
     public RowColumn ParseInputToRowColumn()
     {
-      while(!IsValidRowColInput(chars))
       {
         var input = Console.ReadLine();
         var chars = input.Split(" ", StringSplitOptions.None);
-        try
-        {
-          return new RowColumn(int.Parse(chars[0]), int.Parse(chars[1]));
-        }
-        catch (IndexOutOfRangeException)
-        {
-        }
+        return new RowColumn(int.Parse(chars[0]), int.Parse(chars[1]));
       }
     }
-    public static bool IsValidRowColInput(string[] chars) => chars.Length == 2;
   }
 }

--- a/MineSweeper/ConsoleImplementation/ConsoleInput.cs
+++ b/MineSweeper/ConsoleImplementation/ConsoleInput.cs
@@ -23,12 +23,12 @@ namespace MineSweeper.ConsoleImplementation
       Console.WriteLine("Enter dimensions you want for your field");
       var userInput = Console.ReadLine();
 
-      if (CheckInput(userInput))
-      {
+      // if (CheckInput(userInput))
+      // {
         SquareDimensions = int.Parse(userInput);
         return;
-      }
-      while (!CheckInput(userInput)) ;
+      // }
+      // while (!CheckInput(userInput)) ;
     }
     public void GetValidInput(string userInput)
     {

--- a/MineSweeper/ConsoleImplementation/ConsoleInput.cs
+++ b/MineSweeper/ConsoleImplementation/ConsoleInput.cs
@@ -20,17 +20,21 @@ namespace MineSweeper.ConsoleImplementation
     }
     public void PromptDimensions()
     {
-      Console.WriteLine("Enter dimensions you want for your field (range 3-50)");
+      Console.WriteLine("Enter dimensions you want for your field");
       var userInput = Console.ReadLine();
-      do
+
+      if (CheckInput(userInput))
       {
-        CheckInput(userInput);
-        if (CheckInput(userInput))
-        {
-          SquareDimensions = int.Parse(userInput);
-          return;
-        }
-      } while (!CheckInput(userInput));
+        SquareDimensions = int.Parse(userInput);
+        return;
+      }
+      while (!CheckInput(userInput)) ;
+    }
+    public void GetValidInput(string userInput)
+    {
+      Console.WriteLine("dimensions must be between 3 and 30");
+      CheckInput(userInput);
+      userInput = Console.ReadLine();
     }
 
     public static bool CheckInput(string input)

--- a/MineSweeper/ConsoleImplementation/ConsoleInput.cs
+++ b/MineSweeper/ConsoleImplementation/ConsoleInput.cs
@@ -20,17 +20,17 @@ namespace MineSweeper.ConsoleImplementation
     }
     public void PromptDimensions()
     {
+      Console.WriteLine("Enter dimensions you want for your field (range 3-50)");
+      var userInput = Console.ReadLine();
       do
       {
-        Console.WriteLine("Enter dimensions you want for your field (rang 3-50)");
-        var userInput = Console.ReadLine();
         CheckInput(userInput);
         if (CheckInput(userInput))
         {
           SquareDimensions = int.Parse(userInput);
           return;
         }
-      } while (!CheckInput(Console.ReadLine()));
+      } while (!CheckInput(userInput));
     }
 
     public static bool CheckInput(string input)

--- a/MineSweeper/GameCore/Game.cs
+++ b/MineSweeper/GameCore/Game.cs
@@ -7,7 +7,7 @@ namespace MineSweeper
   public class Game
   {
     private readonly MineField _field;
-    public bool Haslost;
+    public bool PlayerLost;
 
     public Game(MineField field)
     {
@@ -18,24 +18,24 @@ namespace MineSweeper
     {
       return this._field.FieldAsString();
     }
-    public void HandleSelectedSquare(RowColumn selectedSquare)
+    public void HandleSelectedSquare(RowColumn squareIndex)
     {
-      if (IsMine(selectedSquare))
+      if (_field[squareIndex].SquareType == SquareType.Mine)
       {
         FindAndRevealMines();
-        this.Haslost = true;
+        this.PlayerLost = true;
       }
-      if (_field[selectedSquare].IsRevealed)
+      if (_field[squareIndex].IsRevealed)
       {
         return;
       }
-      if (!IsMine(selectedSquare) || _field[selectedSquare].SquareType != 0)
+      if (_field[squareIndex].SquareType != SquareType.Mine || _field[squareIndex].SquareType != 0)
       {
-        _field[selectedSquare].IsRevealed = true;
+        _field[squareIndex].IsRevealed = true;
       }
-      if (_field[selectedSquare].SquareType == 0)
+      if (_field[squareIndex].SquareType == 0)
       {
-        RevealAllAssociatedAdjacentSquaresProcess(selectedSquare);
+        RevealAllAssociatedAdjacentSquaresProcess(squareIndex);
       }
     }
     public void RevealAllAssociatedAdjacentSquaresProcess(RowColumn selectedSquare)
@@ -46,10 +46,11 @@ namespace MineSweeper
         HandleSelectedSquare(index);
       }
     }
-    public bool IsMine(RowColumn index)
-    {
-      return SquareType.Mine == _field[index].SquareType;
-    }
+    // is mine, maybedon't need this, can just be like 'is mine' kept in mienfield coz it's usd as a perdicate for other funcs
+    // public bool IsMine(RowColumn index)
+    // {
+    //   return SquareType.Mine == _field[index].SquareType;
+    // }
     private void FindAndRevealMines()
     {
       foreach (var square in _field.Where(square => square.SquareType == SquareType.Mine))

--- a/MineSweeper/GameCore/Game.cs
+++ b/MineSweeper/GameCore/Game.cs
@@ -20,23 +20,28 @@ namespace MineSweeper
     }
     public void HandleSelectedSquare(RowColumn squareIndex)
     {
-      //exception here
-      if (_field[squareIndex].SquareType == SquareType.Mine)
+      try
       {
-        FindAndRevealMines();
-        this.PlayerLost = true;
+        if (_field[squareIndex].SquareType == SquareType.Mine)
+        {
+          FindAndRevealMines();
+          this.PlayerLost = true;
+        }
+        if (_field[squareIndex].IsRevealed)
+        {
+          return;
+        }
+        if (_field[squareIndex].SquareType != SquareType.Mine || _field[squareIndex].SquareType != 0)
+        {
+          _field[squareIndex].IsRevealed = true;
+        }
+        if (_field[squareIndex].SquareType == 0)
+        {
+          RevealAllAssociatedAdjacentSquaresProcess(squareIndex);
+        }
       }
-      if (_field[squareIndex].IsRevealed)
+      catch (IndexOutOfRangeException)
       {
-        return;
-      }
-      if (_field[squareIndex].SquareType != SquareType.Mine || _field[squareIndex].SquareType != 0)
-      {
-        _field[squareIndex].IsRevealed = true;
-      }
-      if (_field[squareIndex].SquareType == 0)
-      {
-        RevealAllAssociatedAdjacentSquaresProcess(squareIndex);
       }
     }
     public void RevealAllAssociatedAdjacentSquaresProcess(RowColumn selectedSquare)
@@ -47,11 +52,6 @@ namespace MineSweeper
         HandleSelectedSquare(index);
       }
     }
-    // is mine, maybedon't need this, can just be like 'is mine' kept in mienfield coz it's usd as a perdicate for other funcs
-    // public bool IsMine(RowColumn index)
-    // {
-    //   return SquareType.Mine == _field[index].SquareType;
-    // }
     private void FindAndRevealMines()
     {
       foreach (var square in _field.Where(square => square.SquareType == SquareType.Mine))

--- a/MineSweeper/GameCore/Game.cs
+++ b/MineSweeper/GameCore/Game.cs
@@ -20,6 +20,7 @@ namespace MineSweeper
     }
     public void HandleSelectedSquare(RowColumn squareIndex)
     {
+      //exception here
       if (_field[squareIndex].SquareType == SquareType.Mine)
       {
         FindAndRevealMines();

--- a/MineSweeper/GameCore/MineField.cs
+++ b/MineSweeper/GameCore/MineField.cs
@@ -12,28 +12,37 @@ namespace MineSweeper
     public int RowDimension => _field.GetLength(0);
     public int ColumnDimension => _field.GetLength(1);
     public int MineCount => this.Count(square => square.SquareType == SquareType.Mine);
-
     public int RevealedCount => Coordinates().Where(IsRevealed).Count();
 
     private readonly IMinePositions _minePositioning;
     public MineField(int rowDimension, int columnDimension, IMinePositions minePositioning)
     {
-      if (rowDimension < 3 || columnDimension < 3)
-      {
-        throw new ArgumentException("row and column dimensions are below minimum usable value");
-      }
+      // if (rowDimension < 2 || columnDimension < 2)
+      // {
+      //   throw new ArgumentException("row and column dimensions are below minimum usable value");
+      // }
       _field = new Square[rowDimension, columnDimension];
       _minePositioning = minePositioning;
+      //try
       InitializeField();
     }
     public Square this[RowColumn coord] => _field[coord.Row, coord.Column];
 
     private void InitializeField()
     {
-      FillFieldWithSquares();
-      var mines = _minePositioning.GetMinePositions();
-      PlaceMines(mines);
-      SetSquareHintValues();
+      try
+      {
+        FillFieldWithSquares();
+        var mines = _minePositioning.GetMinePositions();
+        PlaceMines(mines);
+        SetSquareHintValues();
+
+      }
+      catch (IndexOutOfRangeException)
+      {
+        throw new Exception("Mine list contains elements greater than field array dimensions");
+        //delete this object/clean up memory
+      }
     }
     private void FillFieldWithSquares()
     {
@@ -45,6 +54,7 @@ namespace MineSweeper
 
     private void PlaceMines(IEnumerable<RowColumn> mines)
     {
+      //try or throw somth here if out of bounds
       foreach (RowColumn index in mines)
       {
         this[index].SquareType = SquareType.Mine;
@@ -119,10 +129,6 @@ namespace MineSweeper
         }
       }
     }
-    // public bool IsMine(RowColumn index)
-    // {
-    //   return SquareType.Mine == this[index].SquareType;
-    // }
     public bool IsRevealed(RowColumn index)
     {
       return this[index].IsRevealed;

--- a/MineSweeper/GameCore/MineField.cs
+++ b/MineSweeper/GameCore/MineField.cs
@@ -17,10 +17,10 @@ namespace MineSweeper
     private readonly IMinePositions _minePositioning;
     public MineField(int rowDimension, int columnDimension, IMinePositions minePositioning)
     {
-      // if (rowDimension < 2 || columnDimension < 2)
-      // {
-      //   throw new ArgumentException("row and column dimensions are below minimum usable value");
-      // }
+      if (rowDimension < 2 || columnDimension < 2)
+      {
+        throw new ArgumentException("row and column dimensions are below minimum usable value");
+      }
       _field = new Square[rowDimension, columnDimension];
       _minePositioning = minePositioning;
       //try

--- a/MineSweeper/GameCore/MineField.cs
+++ b/MineSweeper/GameCore/MineField.cs
@@ -30,7 +30,6 @@ namespace MineSweeper
       catch (IndexOutOfRangeException)
       {
         throw new ArgumentException("Mine list contains elements greater than field array dimensions");
-        //delete this object/clean up memory
       }
     }
     public Square this[RowColumn coord] => _field[coord.Row, coord.Column];
@@ -52,7 +51,6 @@ namespace MineSweeper
 
     private void PlaceMines(IEnumerable<RowColumn> mines)
     {
-      //try or throw somth here if out of bounds
       foreach (RowColumn index in mines)
       {
         this[index].SquareType = SquareType.Mine;

--- a/MineSweeper/GameCore/MineField.cs
+++ b/MineSweeper/GameCore/MineField.cs
@@ -18,6 +18,10 @@ namespace MineSweeper
     private readonly IMinePositions _minePositioning;
     public MineField(int rowDimension, int columnDimension, IMinePositions minePositioning)
     {
+      if (rowDimension < 3 || columnDimension < 3)
+      {
+        throw new ArgumentException("row and column dimensions are below minimum usable value");
+      }
       _field = new Square[rowDimension, columnDimension];
       _minePositioning = minePositioning;
       InitializeField();

--- a/MineSweeper/GameCore/MineField.cs
+++ b/MineSweeper/GameCore/MineField.cs
@@ -29,7 +29,7 @@ namespace MineSweeper
       }
       catch (IndexOutOfRangeException)
       {
-        throw new Exception("Mine list contains elements greater than field array dimensions");
+        throw new ArgumentException("Mine list contains elements greater than field array dimensions");
         //delete this object/clean up memory
       }
     }

--- a/MineSweeper/GameCore/MineField.cs
+++ b/MineSweeper/GameCore/MineField.cs
@@ -77,7 +77,7 @@ namespace MineSweeper
       var count = 0;
       foreach (RowColumn index in neighbourList)
       {
-        if (_field[index.Row, index.Column].SquareType == SquareType.Mine)
+        if (this[index].SquareType == SquareType.Mine)
         {
           count++;
         }

--- a/MineSweeper/GameCore/MineField.cs
+++ b/MineSweeper/GameCore/MineField.cs
@@ -23,26 +23,24 @@ namespace MineSweeper
       }
       _field = new Square[rowDimension, columnDimension];
       _minePositioning = minePositioning;
-      //try
-      InitializeField();
-    }
-    public Square this[RowColumn coord] => _field[coord.Row, coord.Column];
-
-    private void InitializeField()
-    {
       try
       {
-        FillFieldWithSquares();
-        var mines = _minePositioning.GetMinePositions();
-        PlaceMines(mines);
-        SetSquareHintValues();
-
+        InitializeField();
       }
       catch (IndexOutOfRangeException)
       {
         throw new Exception("Mine list contains elements greater than field array dimensions");
         //delete this object/clean up memory
       }
+    }
+    public Square this[RowColumn coord] => _field[coord.Row, coord.Column];
+
+    private void InitializeField()
+    {
+      FillFieldWithSquares();
+      var mines = _minePositioning.GetMinePositions();
+      PlaceMines(mines);
+      SetSquareHintValues();
     }
     private void FillFieldWithSquares()
     {

--- a/MineSweeper/GameCore/MineField.cs
+++ b/MineSweeper/GameCore/MineField.cs
@@ -22,7 +22,6 @@ namespace MineSweeper
       _minePositioning = minePositioning;
       InitializeField();
     }
-
     public Square this[RowColumn coord] => _field[coord.Row, coord.Column];
 
     private void InitializeField()
@@ -66,7 +65,7 @@ namespace MineSweeper
     }
     public int AdjacentMineCount(IEnumerable<RowColumn> neighbourList)
     {
-      int count = 0;
+      var count = 0;
 
       foreach (RowColumn index in neighbourList)
       {
@@ -116,10 +115,10 @@ namespace MineSweeper
         }
       }
     }
-    public bool IsMine(RowColumn index)
-    {
-      return SquareType.Mine == this[index].SquareType;
-    }
+    // public bool IsMine(RowColumn index)
+    // {
+    //   return SquareType.Mine == this[index].SquareType;
+    // }
     public bool IsRevealed(RowColumn index)
     {
       return this[index].IsRevealed;

--- a/MineSweeper/GameCore/MineField.cs
+++ b/MineSweeper/GameCore/MineField.cs
@@ -48,7 +48,6 @@ namespace MineSweeper
         _field[coord.Row, coord.Column] = new Square(SquareType.Zero);
       }
     }
-
     private void PlaceMines(IEnumerable<RowColumn> mines)
     {
       foreach (RowColumn index in mines)
@@ -58,10 +57,10 @@ namespace MineSweeper
     }
     public IEnumerable<RowColumn> GetNeighboursOfSquare(int row, int column)
     {
-      var leftNeighbour = (column - 1);
-      var rightNeighbour = (column + 1);
-      var upNeighbour = (row - 1);
-      var downNeighbour = (row + 1);
+      var leftNeighbour = column - 1;
+      var rightNeighbour = column + 1;
+      var upNeighbour = row - 1;
+      var downNeighbour = row + 1;
 
       var neighbourList = new List<RowColumn>{
         new RowColumn(row, rightNeighbour), new RowColumn(row, leftNeighbour), new RowColumn(upNeighbour, column), new RowColumn(downNeighbour, column), new RowColumn(upNeighbour, rightNeighbour), new RowColumn(upNeighbour, leftNeighbour), new RowColumn(downNeighbour, rightNeighbour), new RowColumn(downNeighbour, leftNeighbour)
@@ -76,7 +75,6 @@ namespace MineSweeper
     public int AdjacentMineCount(IEnumerable<RowColumn> neighbourList)
     {
       var count = 0;
-
       foreach (RowColumn index in neighbourList)
       {
         if (_field[index.Row, index.Column].SquareType == SquareType.Mine)

--- a/MineSweeper/GameCore/RandomMinePositions.cs
+++ b/MineSweeper/GameCore/RandomMinePositions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 
 namespace MineSweeper
 {
-
   public class RandomMinePositions : IMinePositions
   {
     private readonly int _rowDimension;
@@ -38,6 +37,5 @@ namespace MineSweeper
       }
       return minesPositions;
     }
-
   }
 }

--- a/MineSweeper/GameCore/Square.cs
+++ b/MineSweeper/GameCore/Square.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace MineSweeper
 {
   public class Square
@@ -16,7 +18,7 @@ namespace MineSweeper
       var nonRevealedSymbol = this.IsFlagged ? "F" : " ";
       return this.IsRevealed ? this.GetSquareSymbol() : nonRevealedSymbol;
     }
-  public string GetSquareSymbol()
+    public string GetSquareSymbol()
     {
       return SquareType switch
       {
@@ -30,7 +32,7 @@ namespace MineSweeper
         SquareType.Seven => "7",
         SquareType.Eight => "8",
         SquareType.Mine => "*",
-        // _ => " "
+        _ => throw new ArgumentException(nameof(SquareType))
       };
     }
   }

--- a/MineSweeper/GamePlay.cs
+++ b/MineSweeper/GamePlay.cs
@@ -11,12 +11,9 @@ namespace MineSweeper
       {
         try
         {
-          ProcessTurn(outPut, userInput, game);
+          ProcessHit(outPut, userInput, game);
         }
-        catch (Exception ex) when (
-    ex is IndexOutOfRangeException
-    || ex is FormatException
-)
+        catch (Exception ex) when (ex is IndexOutOfRangeException || ex is FormatException)
         {
         }
       } while (!game.HasWon() && !game.PlayerLost);
@@ -24,9 +21,9 @@ namespace MineSweeper
       var endMessage = game.HasWon() ? "Well done" : "You lost";
       outPut.Write(endMessage);
     }
-    public static void ProcessTurn(IOutPut outPut, IUserInput userInput, Game game)
+    public static void ProcessHit(IOutPut outPut, IUserInput userInput, Game game)
     {
-      outPut.Write("Enter a row column index to 'hit'");
+      outPut.Write("Enter a row column index to 'hit' eg: '0 0'");
       outPut.Write(game.GetCurrentField());
       game.HandleSelectedSquare(userInput.ParseInputToRowColumn());
     }

--- a/MineSweeper/GamePlay.cs
+++ b/MineSweeper/GamePlay.cs
@@ -9,14 +9,24 @@ namespace MineSweeper
       var game = new Game(mineField);
       do
       {
-        outPut.Write("Enter a row column index to 'hit'");
-        outPut.Write(game.GetCurrentField());
-        game.HandleSelectedSquare(userInput.ParseInputToRowColumn());
+        try
+        {
+          ProcessTurn(outPut, userInput, game);
+        }
+        catch (FormatException)
+        {
+        }
 
       } while (!game.HasWon() && !game.PlayerLost);
       outPut.Write(game.GetCurrentField());
       var endMessage = game.HasWon() ? "Well done" : "You lost";
       outPut.Write(endMessage);
+    }
+    public static void ProcessTurn(IOutPut outPut, IUserInput userInput, Game game)
+    {
+      outPut.Write("Enter a row column index to 'hit'");
+      outPut.Write(game.GetCurrentField());
+      game.HandleSelectedSquare(userInput.ParseInputToRowColumn());
     }
   }
 }

--- a/MineSweeper/GamePlay.cs
+++ b/MineSweeper/GamePlay.cs
@@ -13,10 +13,12 @@ namespace MineSweeper
         {
           ProcessTurn(outPut, userInput, game);
         }
-        catch (FormatException)
+        catch (Exception ex) when (
+    ex is IndexOutOfRangeException
+    || ex is FormatException
+)
         {
         }
-
       } while (!game.HasWon() && !game.PlayerLost);
       outPut.Write(game.GetCurrentField());
       var endMessage = game.HasWon() ? "Well done" : "You lost";

--- a/MineSweeper/GamePlay.cs
+++ b/MineSweeper/GamePlay.cs
@@ -13,7 +13,7 @@ namespace MineSweeper
         outPut.Write(game.GetCurrentField());
         game.HandleSelectedSquare(userInput.ParseInputToRowColumn());
 
-      } while (!game.HasWon() && !game.Haslost);
+      } while (!game.HasWon() && !game.PlayerLost);
       outPut.Write(game.GetCurrentField());
       var endMessage = game.HasWon() ? "Well done" : "You lost";
       outPut.Write(endMessage);

--- a/MineSweeper/IUserInput.cs
+++ b/MineSweeper/IUserInput.cs
@@ -2,7 +2,7 @@ namespace MineSweeper
 {
   public interface IUserInput
   {
-    void Read();
+    string ReadInput(string message);
     RowColumn ParseInputToRowColumn();
   }
 }

--- a/MineSweeper/Program.cs
+++ b/MineSweeper/Program.cs
@@ -10,10 +10,10 @@ namespace MineSweeper
     {
       var userInput = new ConsoleInput();
       var outPut = new ConsoleOutput();
-      // userInput.PromptDimensions();
-      userInput.SquareDimensions = 5;
-      // var minePositioning = new RandomMinePositions(userInput.SquareDimensions, userInput.SquareDimensions, userInput.SquareDimensions);
-      var minePositioning = new SetMinePositions(new HashSet<RowColumn>{new RowColumn(1,1)});
+      userInput.PromptDimensions();
+      // userInput.SquareDimensions = 0;
+      var minePositioning = new RandomMinePositions(userInput.SquareDimensions, userInput.SquareDimensions, userInput.SquareDimensions);
+      // var minePositioning = new SetMinePositions(new HashSet<RowColumn>{});
       var mineField = new MineField(userInput.SquareDimensions, userInput.SquareDimensions, minePositioning);
       GamePlay.Run(outPut, userInput, mineField);
     }

--- a/MineSweeper/Program.cs
+++ b/MineSweeper/Program.cs
@@ -10,7 +10,7 @@ namespace MineSweeper
     {
       var userInput = new ConsoleInput();
       var outPut = new ConsoleOutput();
-      userInput.PromptDimensions();
+      userInput.GetValidDimensions();
       // userInput.SquareDimensions = 0;
       var minePositioning = new RandomMinePositions(userInput.SquareDimensions, userInput.SquareDimensions, userInput.SquareDimensions);
       // var minePositioning = new SetMinePositions(new HashSet<RowColumn>{});

--- a/MineSweeper/Program.cs
+++ b/MineSweeper/Program.cs
@@ -10,11 +10,9 @@ namespace MineSweeper
     {
       var userInput = new ConsoleInput();
       var outPut = new ConsoleOutput();
-      userInput.GetValidDimensions();
-      // userInput.SquareDimensions = 0;
-      var minePositioning = new RandomMinePositions(userInput.SquareDimensions, userInput.SquareDimensions, userInput.SquareDimensions);
-      // var minePositioning = new SetMinePositions(new HashSet<RowColumn>{});
-      var mineField = new MineField(userInput.SquareDimensions, userInput.SquareDimensions, minePositioning);
+      var dimensions = userInput.GetValidDimensions();
+      var minePositioning = new RandomMinePositions(dimensions, dimensions, dimensions);
+      var mineField = new MineField(dimensions, dimensions, minePositioning);
       GamePlay.Run(outPut, userInput, mineField);
     }
   }


### PR DESCRIPTION
error handling.

The Minefield constructor can throw an argument exception error. My thinking behind this is that it shouldn't complete/ make a minefiled if it is passed in arguments that will make a minefiled object that is unusable - which could happen if dimensions are dumb, or if a set mine positioning/seeded game puts through mines that are out of bounds. Both of these will throw a argument exception. The latter catches an index out of range exception and throws the argument exception.  Will ask for feedback on the appropriateness of this and also the implications of memory allocation - what happens when this throws?

in Game the HandleSelectedSquare func can catch a index out of range ex, this is because it's possible a rowcolumn index could be passed in here and break everything - there are places that try and prevent this eariler on, but it seemed best to put something here too. it can just ignore it.

GamePlay will catch exceptions - index out of range or format, this is because it's possible the data from input could be bad and there's no erason to break the game, just take it again if bad stuff gets through. Console UserInput class tries to prevent bad stuff getting through but better safe than sorry and GamePlay is not just for console so needs some error handling.

console user input parseinputtorowcolumn has possibility to throw an index out of range ex because of the way it splits the string. I could write a func that just makes sure it gets a valid one and leave the catching in game play, I'm just not very interested in spending much time writing validation patterns/loops for the console implementation so might leave it for now.

